### PR TITLE
Add BattleTalk reader support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Verify package
         shell: pwsh
-        run: ./tools/Verify-Package.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.1.4 -ExpectedRepositoryCommit $env:GITHUB_SHA
+        run: ./tools/Verify-Package.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.2.0 -ExpectedRepositoryCommit $env:GITHUB_SHA
 
       - name: Verify clean package consumer
         shell: pwsh
-        run: ./tools/Verify-PackageConsumer.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.1.4 -ExpectedRepositoryCommit $env:GITHUB_SHA
+        run: ./tools/Verify-PackageConsumer.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.2.0 -ExpectedRepositoryCommit $env:GITHUB_SHA
 
       - name: Upload package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       package_version:
-        description: NuGet package version, for example 9.1.4
+        description: NuGet package version, for example 9.2.0
         required: true
         type: string
       publish:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sharlayan.Lite
 
-This fork is a lightweight version of the original library and only has memory search & ChatLog functionality.
+This fork is a lightweight version of the original library with memory search, ChatLog, and dialogue UI readers.
 
 Supported targets: .NET Framework 4.6.2 and 4.8, plus .NET 6, 7, 8, and 10.
 
@@ -12,9 +12,9 @@ Supported targets: .NET Framework 4.6.2 and 4.8, plus .NET 6, 7, 8, and 10.
 
 # How do I use it and what comes back?
 
-- .NET CLI: `dotnet add package Sharlayan.Lite --version 9.1.4`
-- Nuget Package Manager: `Install-Package Sharlayan.Lite -Version 9.1.4`
-- PackageReference: `<PackageReference Include="Sharlayan.Lite" Version="9.1.4" />`
+- .NET CLI: `dotnet add package Sharlayan.Lite --version 9.2.0`
+- Nuget Package Manager: `Install-Package Sharlayan.Lite -Version 9.2.0`
+- PackageReference: `<PackageReference Include="Sharlayan.Lite" Version="9.2.0" />`
 
 That's the basic of it. For actual instantiation it works as follows:
 
@@ -115,6 +115,21 @@ back to FCS `LastTalkName`/`LastTalkText` (`Source=Last`, `IsVisible=false`) whe
 available. Use `GetCurrentTalk()` or `GetLastTalk()` when the distinction is part of the caller's policy.
 Applications consuming the last value should baseline the first value after attach before treating changes
 as new dialogue.
+
+## BattleTalk Reading
+
+```csharp
+if (memoryHandler.Reader.CanGetBattleTalk()) {
+    BattleTalkResult battleTalk = memoryHandler.Reader.GetBattleTalk();
+    if (battleTalk.IsAvailable && battleTalk.IsVisible) {
+        Console.WriteLine($"{battleTalk.Sequence}: {battleTalk.Name}: {battleTalk.Text}");
+    }
+}
+```
+
+The optional capability returns `false` when the selected Hermes manifest does not contain its
+resource. `BattleTalkResult.Sequence` increases for each stable visible generation observed during the
+handler lifetime, including the same name/text pair after a stable hidden state.
 
 The selected resource can be inspected through `memoryHandler.ResourceInfo`, including its source,
 revision, FCS/generator commits, validation status, resolved location count, and fallback reason.

--- a/Sharlayan.Tests/Resources/BattleTalkContractProbeTests.cs
+++ b/Sharlayan.Tests/Resources/BattleTalkContractProbeTests.cs
@@ -1,0 +1,256 @@
+namespace Sharlayan.Tests.Resources {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    using Sharlayan.Models.Resources;
+    using Sharlayan.Resources;
+
+    using Xunit;
+
+    public sealed class BattleTalkContractProbeTests {
+        [Fact]
+        public void CapturesAddonArraysAndQueueWithoutExposingText() {
+            SyntheticBattleTalkMemory memory = SyntheticBattleTalkMemory.Create();
+
+            BattleTalkProbeObservation result =
+                BattleTalkContractProbe.Read(memory.Peek, memory.UiModulePointerAddress, memory.Layout);
+
+            Assert.True(result.Addon.IsReadable);
+            Assert.True(result.Addon.IsFound);
+            Assert.True(result.Addon.IsVisible);
+            Assert.True(result.Addon.IsReady);
+            Assert.Single(result.Addon.Strings);
+            Assert.Equal(2, result.NumberArray.Values.Count);
+            Assert.Equal(17, result.NumberArray.Values[0]);
+            Assert.Single(result.StringArray.Values);
+            Assert.Equal(2, result.QueueSlots.Count);
+            Assert.True(result.QueueSlots[0].IsReadable);
+            Assert.True(result.QueueSlots[0].IsPending);
+            Assert.Equal(6, result.QueueSlots[0].Name.Utf8Length);
+            Assert.Equal(13, result.QueueSlots[0].Text.Utf8Length);
+            Assert.DoesNotContain("Ysayle", result.Fingerprint);
+            Assert.DoesNotContain("Hold the line", result.Fingerprint);
+        }
+
+        [Fact]
+        public void MarksCorruptQueueSlotUnreadableAndRejectsInvalidLayout() {
+            SyntheticBattleTalkMemory memory = SyntheticBattleTalkMemory.Create();
+            memory.WriteBytes(memory.QueueName, new byte[] { 0xC3, 0x28, 0 });
+
+            BattleTalkProbeObservation result =
+                BattleTalkContractProbe.Read(memory.Peek, memory.UiModulePointerAddress, memory.Layout);
+
+            Assert.False(result.QueueSlots[0].IsReadable);
+
+            memory.Layout.AgentHud.QueueCapacity = 0;
+            Assert.Throws<System.IO.InvalidDataException>(
+                () => BattleTalkContractProbe.Read(memory.Peek, memory.UiModulePointerAddress, memory.Layout));
+        }
+
+        private sealed class SyntheticBattleTalkMemory {
+            private const long UiModule = 0x10000;
+            private readonly Dictionary<long, byte> memory = new Dictionary<long, byte>();
+
+            private SyntheticBattleTalkMemory() {
+                this.Layout = CreateLayout();
+                this.UiModulePointerAddress = new IntPtr(0x1000);
+                long raptureAtkModule = UiModule + this.Layout.Ui.RaptureAtkModuleOffset;
+                long list = raptureAtkModule
+                            + this.Layout.Addon.RaptureAtkUnitManagerOffset
+                            + this.Layout.Addon.AllLoadedUnitsListOffset;
+                long addon = 0x20000;
+                long atkValues = 0x21000;
+                long addonText = 0x22000;
+                long holder = raptureAtkModule + this.Layout.Arrays.AtkArrayDataHolderOffset;
+                long numberPointers = 0x30000;
+                long numberData = 0x31000;
+                long numberValues = 0x32000;
+                long stringPointers = 0x33000;
+                long stringData = 0x34000;
+                long stringValues = 0x35000;
+                long stringText = 0x36000;
+                long agentModule = raptureAtkModule + this.Layout.AgentHud.AgentModuleOffset;
+                long agents = agentModule + this.Layout.AgentHud.AgentsOffset;
+                long hud = 0x40000;
+                long queue = hud + this.Layout.AgentHud.QueueOffset;
+                this.QueueName = 0x41000;
+                this.QueueText = 0x42000;
+
+                this.WritePointer(this.UiModulePointerAddress.ToInt64(), UiModule);
+                this.WriteUInt16(list + this.Layout.Addon.AtkUnitList.CountOffset, 1);
+                this.WritePointer(list + this.Layout.Addon.AtkUnitList.EntriesOffset, addon);
+                this.WriteFixedString(addon + this.Layout.Addon.AtkUnitBase.NameOffset, 32, "_BattleTalk");
+                this.WriteUInt32(
+                    addon + this.Layout.Addon.AtkUnitBase.VisibilityStateOffset,
+                    this.Layout.Addon.AtkUnitBase.VisibilityMask);
+                this.WriteByte(addon + this.Layout.Addon.AtkUnitBase.ReadinessOffset, 1);
+                this.WritePointer(addon + this.Layout.Addon.AtkUnitBase.AtkValuesPointerOffset, atkValues);
+                this.WriteUInt16(addon + this.Layout.Addon.AtkUnitBase.AtkValuesCountOffset, 1);
+                this.WriteInt32(atkValues, 0x28);
+                this.WritePointer(atkValues + 8, addonText);
+                this.WriteCString(addonText, "Hold the line");
+
+                this.WriteInt16(holder + this.Layout.Arrays.NumberArrayCountOffset, 2);
+                this.WritePointer(holder + this.Layout.Arrays.NumberArraysOffset, numberPointers);
+                this.WritePointer(numberPointers + 8, numberData);
+                this.WriteInt32(numberData + this.Layout.Arrays.ArraySizeOffset, 2);
+                this.WriteByte(numberData + this.Layout.Arrays.ArrayUpdateStateOffset, 3);
+                this.WritePointer(numberData + this.Layout.Arrays.NumberValuesOffset, numberValues);
+                this.WriteInt32(numberValues, 17);
+                this.WriteInt32(numberValues + 4, 23);
+
+                this.WriteInt16(holder + this.Layout.Arrays.StringArrayCountOffset, 2);
+                this.WritePointer(holder + this.Layout.Arrays.StringArraysOffset, stringPointers);
+                this.WritePointer(stringPointers + 8, stringData);
+                this.WriteInt32(stringData + this.Layout.Arrays.ArraySizeOffset, 1);
+                this.WriteByte(stringData + this.Layout.Arrays.ArrayUpdateStateOffset, 4);
+                this.WritePointer(stringData + this.Layout.Arrays.StringValuesOffset, stringValues);
+                this.WritePointer(stringValues, stringText);
+                this.WriteCString(stringText, "Hold the line");
+
+                this.WritePointer(agents + 8, hud);
+                this.WriteQueueSlot(queue, true, this.QueueName, "Ysayle", this.QueueText, "Hold the line");
+                this.WriteQueueSlot(
+                    queue + this.Layout.AgentHud.QueueEntrySize,
+                    false,
+                    0x43000,
+                    string.Empty,
+                    0x44000,
+                    string.Empty);
+            }
+
+            internal BattleTalkProbeLayout Layout { get; }
+            internal IntPtr UiModulePointerAddress { get; }
+            internal long QueueName { get; }
+            internal long QueueText { get; }
+
+            internal static SyntheticBattleTalkMemory Create() => new SyntheticBattleTalkMemory();
+
+            internal bool Peek(IntPtr address, byte[] buffer, int count) {
+                for (int index = 0; index < count; index++) {
+                    if (!this.memory.TryGetValue(address.ToInt64() + index, out byte value)) return false;
+                    buffer[index] = value;
+                }
+
+                return true;
+            }
+
+            internal void WriteBytes(long address, byte[] bytes) {
+                for (int index = 0; index < bytes.Length; index++) this.memory[address + index] = bytes[index];
+            }
+
+            private static BattleTalkProbeLayout CreateLayout() {
+                return new BattleTalkProbeLayout {
+                    SchemaVersion = 1,
+                    FcsCommit = "fixture",
+                    Ui = new BattleTalkProbeUiLayout { RaptureAtkModuleOffset = 0x100 },
+                    Addon = new BattleTalkProbeAddonLayout {
+                        RaptureAtkUnitManagerOffset = 0x200,
+                        AllLoadedUnitsListOffset = 0x300,
+                        AtkUnitList = new HermesAtkUnitListLayout {
+                            EntriesOffset = 8,
+                            CountOffset = 0x20,
+                            Capacity = 4,
+                            EntrySize = 8,
+                        },
+                        AtkUnitBase = new HermesAtkUnitBaseLayout {
+                            NameOffset = 8,
+                            NameCapacity = 32,
+                            VisibilityStateOffset = 0x40,
+                            VisibilityMask = 0x20,
+                            ReadinessOffset = 0x44,
+                            ReadinessMask = 1,
+                            AtkValuesPointerOffset = 0x48,
+                            AtkValuesCountOffset = 0x50,
+                        },
+                        AtkValue = new HermesAtkValueLayout {
+                            Size = 16,
+                            TypeOffset = 0,
+                            ValueOffset = 8,
+                            AllowedStringTypes = new List<int> { 0x28 },
+                        },
+                        BattleTalkAddonName = "_BattleTalk",
+                    },
+                    Arrays = new BattleTalkProbeArrayLayout {
+                        AtkArrayDataHolderOffset = 0x400,
+                        NumberArrayCountOffset = 0,
+                        NumberArraysOffset = 8,
+                        StringArrayCountOffset = 2,
+                        StringArraysOffset = 16,
+                        ArraySizeOffset = 0,
+                        ArrayUpdateStateOffset = 4,
+                        NumberValuesOffset = 8,
+                        StringValuesOffset = 8,
+                        BattleTalkNumberArrayId = 1,
+                        BattleTalkStringArrayId = 1,
+                    },
+                    AgentHud = new BattleTalkProbeAgentHudLayout {
+                        AgentModuleOffset = 0x500,
+                        AgentsOffset = 8,
+                        AgentsCapacity = 4,
+                        AgentEntrySize = 8,
+                        HudAgentId = 1,
+                        QueueOffset = 0x100,
+                        QueueCapacity = 2,
+                        QueueEntrySize = 0x80,
+                        IsPendingOffset = 0,
+                        StyleOffset = 1,
+                        NameOffset = 8,
+                        TextOffset = 40,
+                        ImageOffset = 72,
+                        SoundOffset = 76,
+                        EntityIdOffset = 80,
+                    },
+                    Utf8String = new HermesUtf8StringLayout {
+                        StringPointerOffset = 0,
+                        BufferUsedOffset = 16,
+                    },
+                };
+            }
+
+            private void WriteQueueSlot(
+                long entry,
+                bool pending,
+                long namePointer,
+                string name,
+                long textPointer,
+                string text) {
+                this.WriteByte(entry, pending ? (byte) 1 : (byte) 0);
+                this.WriteByte(entry + 1, 2);
+                this.WriteUtf8String(entry + 8, namePointer, name);
+                this.WriteUtf8String(entry + 40, textPointer, text);
+                this.WriteUInt32(entry + 72, 101);
+                this.WriteInt32(entry + 76, 202);
+                this.WriteUInt32(entry + 80, 303);
+            }
+
+            private void WriteUtf8String(long address, long pointer, string value) {
+                byte[] bytes = Encoding.UTF8.GetBytes(value + "\0");
+                this.WritePointer(address, pointer);
+                this.WriteInt64(address + 16, bytes.Length);
+                this.WriteBytes(pointer, bytes);
+            }
+
+            private void WriteCString(long address, string value) {
+                byte[] bytes = new byte[256];
+                Encoding.UTF8.GetBytes(value, 0, value.Length, bytes, 0);
+                this.WriteBytes(address, bytes);
+            }
+
+            private void WriteFixedString(long address, int capacity, string value) {
+                byte[] bytes = new byte[capacity];
+                Encoding.ASCII.GetBytes(value, 0, value.Length, bytes, 0);
+                this.WriteBytes(address, bytes);
+            }
+
+            private void WriteByte(long address, byte value) => this.memory[address] = value;
+            private void WriteInt16(long address, short value) => this.WriteBytes(address, BitConverter.GetBytes(value));
+            private void WriteUInt16(long address, ushort value) => this.WriteBytes(address, BitConverter.GetBytes(value));
+            private void WriteInt32(long address, int value) => this.WriteBytes(address, BitConverter.GetBytes(value));
+            private void WriteUInt32(long address, uint value) => this.WriteBytes(address, BitConverter.GetBytes(value));
+            private void WriteInt64(long address, long value) => this.WriteBytes(address, BitConverter.GetBytes(value));
+            private void WritePointer(long address, long value) => this.WriteInt64(address, value);
+        }
+    }
+}

--- a/Sharlayan.Tests/Resources/BattleTalkMemoryReaderTests.cs
+++ b/Sharlayan.Tests/Resources/BattleTalkMemoryReaderTests.cs
@@ -1,0 +1,213 @@
+namespace Sharlayan.Tests.Resources {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    using Sharlayan.Resources;
+
+    using Xunit;
+
+    public sealed class BattleTalkMemoryReaderTests {
+        [Fact]
+        public void ReadsVisibleBattleTalkAndReportsStableHiddenOrAbsent() {
+            SyntheticBattleTalkMemory visible = SyntheticBattleTalkMemory.Create();
+            SyntheticBattleTalkMemory hidden = SyntheticBattleTalkMemory.Create();
+            hidden.WriteUInt32(hidden.Addon + hidden.Layout.VisibilityStateOffset, 0);
+            SyntheticBattleTalkMemory absent = SyntheticBattleTalkMemory.Create();
+            absent.WriteUInt16(absent.CountAddress, 0);
+
+            BattleTalkMemoryObservation visibleResult =
+                BattleTalkMemoryReader.Read(visible.Peek, visible.UiModulePointerAddress, visible.Layout);
+            BattleTalkMemoryObservation hiddenResult =
+                BattleTalkMemoryReader.Read(hidden.Peek, hidden.UiModulePointerAddress, hidden.Layout);
+            BattleTalkMemoryObservation absentResult =
+                BattleTalkMemoryReader.Read(absent.Peek, absent.UiModulePointerAddress, absent.Layout);
+
+            Assert.True(visibleResult.IsAvailable);
+            Assert.True(visibleResult.IsVisible);
+            Assert.Equal("Ysayle", visibleResult.Name);
+            Assert.Equal("Hold the line.", visibleResult.Text);
+            Assert.True(hiddenResult.IsAvailable);
+            Assert.False(hiddenResult.IsVisible);
+            Assert.True(absentResult.IsAvailable);
+            Assert.False(absentResult.IsVisible);
+        }
+
+        [Fact]
+        public void RejectsVisibilityDisagreementInvalidUtf8AndOversizedArray() {
+            SyntheticBattleTalkMemory disagreement = SyntheticBattleTalkMemory.Create();
+            disagreement.WriteInt32(disagreement.NumberValues, 0);
+            SyntheticBattleTalkMemory invalidUtf8 = SyntheticBattleTalkMemory.Create();
+            invalidUtf8.WriteCStringBytes(invalidUtf8.TextString, new byte[] { 0xC3, 0x28 });
+            SyntheticBattleTalkMemory oversized = SyntheticBattleTalkMemory.Create();
+            oversized.WriteInt32(oversized.StringData + oversized.Layout.ArraySizeOffset, 4097);
+
+            Assert.False(
+                BattleTalkMemoryReader.Read(
+                    disagreement.Peek,
+                    disagreement.UiModulePointerAddress,
+                    disagreement.Layout).IsAvailable);
+            Assert.False(
+                BattleTalkMemoryReader.Read(
+                    invalidUtf8.Peek,
+                    invalidUtf8.UiModulePointerAddress,
+                    invalidUtf8.Layout).IsAvailable);
+            Assert.False(
+                BattleTalkMemoryReader.Read(
+                    oversized.Peek,
+                    oversized.UiModulePointerAddress,
+                    oversized.Layout).IsAvailable);
+        }
+
+        [Fact]
+        public void SequenceChangesOnContentOrVisibilityGeneration() {
+            BattleTalkSequenceTracker tracker = new BattleTalkSequenceTracker();
+            BattleTalkMemoryObservation first =
+                new BattleTalkMemoryObservation(true, true, "Ysayle", "Hold the line.");
+            BattleTalkMemoryObservation second =
+                new BattleTalkMemoryObservation(true, true, "Ysayle", "Advance.");
+
+            Assert.Equal(1, tracker.Observe(first).Sequence);
+            Assert.Equal(1, tracker.Observe(first).Sequence);
+            Assert.Equal(2, tracker.Observe(second).Sequence);
+            tracker.Observe(BattleTalkMemoryObservation.Hidden);
+            Assert.Equal(3, tracker.Observe(first).Sequence);
+        }
+
+        private sealed class SyntheticBattleTalkMemory {
+            private const long UiModule = 0x10000;
+            private readonly Dictionary<long, byte> memory = new Dictionary<long, byte>();
+
+            private SyntheticBattleTalkMemory() {
+                this.Layout = new BattleTalkMemoryLayout {
+                    RaptureAtkModuleOffset = 0x100,
+                    RaptureAtkUnitManagerOffset = 0x200,
+                    AllLoadedUnitsListOffset = 0x300,
+                    EntriesOffset = 8,
+                    CountOffset = 0x20,
+                    Capacity = 4,
+                    EntrySize = 8,
+                    AddonNameOffset = 8,
+                    AddonNameCapacity = 32,
+                    VisibilityStateOffset = 0x40,
+                    VisibilityMask = 0x20,
+                    ReadinessOffset = 0x44,
+                    ReadinessMask = 1,
+                    AddonName = "_BattleTalk",
+                    AtkArrayDataHolderOffset = 0x400,
+                    NumberArrayCountOffset = 0,
+                    NumberArraysOffset = 8,
+                    StringArrayCountOffset = 2,
+                    StringArraysOffset = 16,
+                    ArraySizeOffset = 0,
+                    ArrayUpdateStateOffset = 4,
+                    NumberValuesOffset = 8,
+                    StringValuesOffset = 8,
+                    NumberArrayId = 0,
+                    StringArrayId = 0,
+                    VisibleIndex = 0,
+                    NameIndex = 0,
+                    TextIndex = 1,
+                };
+                this.UiModulePointerAddress = new IntPtr(0x1000);
+                long rapture = UiModule + this.Layout.RaptureAtkModuleOffset;
+                long list = rapture
+                            + this.Layout.RaptureAtkUnitManagerOffset
+                            + this.Layout.AllLoadedUnitsListOffset;
+                this.CountAddress = list + this.Layout.CountOffset;
+                this.Addon = 0x20000;
+                long holder = rapture + this.Layout.AtkArrayDataHolderOffset;
+                long numberArrays = 0x30000;
+                long numberData = 0x31000;
+                this.NumberValues = 0x32000;
+                long stringArrays = 0x33000;
+                this.StringData = 0x34000;
+                long stringValues = 0x35000;
+                this.NameString = 0x36000;
+                this.TextString = 0x37000;
+
+                this.WritePointer(this.UiModulePointerAddress.ToInt64(), UiModule);
+                this.WriteUInt16(this.CountAddress, 1);
+                this.WritePointer(list + this.Layout.EntriesOffset, this.Addon);
+                this.WriteFixedString(this.Addon + this.Layout.AddonNameOffset, 32, "_BattleTalk");
+                this.WriteUInt32(this.Addon + this.Layout.VisibilityStateOffset, 0x20);
+                this.WriteByte(this.Addon + this.Layout.ReadinessOffset, 1);
+
+                this.WriteInt16(holder, 1);
+                this.WritePointer(holder + 8, numberArrays);
+                this.WritePointer(numberArrays, numberData);
+                this.WriteInt32(numberData, 1);
+                this.WriteByte(numberData + 4, 0);
+                this.WritePointer(numberData + 8, this.NumberValues);
+                this.WriteInt32(this.NumberValues, 7);
+
+                this.WriteInt16(holder + 2, 1);
+                this.WritePointer(holder + 16, stringArrays);
+                this.WritePointer(stringArrays, this.StringData);
+                this.WriteInt32(this.StringData, 2);
+                this.WriteByte(this.StringData + 4, 0);
+                this.WritePointer(this.StringData + 8, stringValues);
+                this.WritePointer(stringValues, this.NameString);
+                this.WritePointer(stringValues + 8, this.TextString);
+                this.WriteCString(this.NameString, "Ysayle");
+                this.WriteCString(this.TextString, "Hold the line.");
+            }
+
+            internal BattleTalkMemoryLayout Layout { get; }
+            internal IntPtr UiModulePointerAddress { get; }
+            internal long CountAddress { get; }
+            internal long Addon { get; }
+            internal long NumberValues { get; }
+            internal long StringData { get; }
+            internal long NameString { get; }
+            internal long TextString { get; }
+
+            internal static SyntheticBattleTalkMemory Create() => new SyntheticBattleTalkMemory();
+
+            internal bool Peek(IntPtr address, byte[] buffer, int count) {
+                for (int index = 0; index < count; index++) {
+                    if (!this.memory.TryGetValue(address.ToInt64() + index, out byte value)) return false;
+                    buffer[index] = value;
+                }
+
+                return true;
+            }
+
+            internal void WriteUInt16(long address, ushort value) =>
+                this.Write(address, BitConverter.GetBytes(value));
+
+            internal void WriteUInt32(long address, uint value) =>
+                this.Write(address, BitConverter.GetBytes(value));
+
+            internal void WriteInt32(long address, int value) =>
+                this.Write(address, BitConverter.GetBytes(value));
+
+            internal void WriteCStringBytes(long address, byte[] value) {
+                byte[] bytes = new byte[256];
+                Buffer.BlockCopy(value, 0, bytes, 0, value.Length);
+                this.Write(address, bytes);
+            }
+
+            private void WriteInt16(long address, short value) =>
+                this.Write(address, BitConverter.GetBytes(value));
+
+            private void WritePointer(long address, long value) =>
+                this.Write(address, BitConverter.GetBytes(value));
+
+            private void WriteByte(long address, byte value) => this.memory[address] = value;
+
+            private void WriteCString(long address, string value) =>
+                this.WriteCStringBytes(address, Encoding.UTF8.GetBytes(value));
+
+            private void WriteFixedString(long address, int capacity, string value) {
+                byte[] bytes = new byte[capacity];
+                Encoding.ASCII.GetBytes(value, 0, value.Length, bytes, 0);
+                this.Write(address, bytes);
+            }
+
+            private void Write(long address, byte[] bytes) {
+                for (int index = 0; index < bytes.Length; index++) this.memory[address + index] = bytes[index];
+            }
+        }
+    }
+}

--- a/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
+++ b/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
@@ -16,29 +16,29 @@ namespace Sharlayan.Tests.Resources {
         public void EmbeddedManifestParsesAndMatchesExpectedRevision() {
             byte[] bytes = ReadEmbeddedFixture();
 
-            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(bytes, null, "9.1.2", allowCandidate: true);
+            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.0", allowCandidate: true);
 
             Assert.Equal(2, manifest.SchemaVersion);
-            Assert.Equal("8ff04195c4e77ef0b85d15c6fd1c67785378f0fb", manifest.Source.FcsCommit);
-            Assert.Equal("sha256:419248bf2ef93aa64e72723ea9e97d5503163178dab63e90a8155b359ebcf96d", HermesV2ManifestParser.CalculateRevision(bytes));
+            Assert.Equal("ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1", manifest.Source.FcsCommit);
+            Assert.Equal("sha256:065e24246f0707101601d76fd23ce159d26f74f60c0368a589ef4da0a7abb701", HermesV2ManifestParser.CalculateRevision(bytes));
         }
 
         [Fact]
         public void RemoteParserAcceptsLiveVerifiedValidation() {
             byte[] bytes = ReadEmbeddedFixture();
 
-            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(bytes, null, "9.1.2", allowCandidate: false);
+            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.0", allowCandidate: false);
 
             Assert.Equal("live-verified", manifest.Validation.Status);
-            Assert.Equal("3e27261f82851e1e88c413a25461e6ca0ad551e8", manifest.Validation.VerifierCommit);
+            Assert.Equal("36ebee4a4926dd45607bf973c6205b8eec04b480", manifest.Validation.VerifierCommit);
         }
 
         [Fact]
         public void ParserRejectsRevisionMismatchAndNewerMinimumVersion() {
             byte[] bytes = CreateLiveManifest("99.0.0");
 
-            Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(bytes, "sha256:" + new string('0', 64), "9.1.2", allowCandidate: false));
-            Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(bytes, null, "9.1.2", allowCandidate: false));
+            Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(bytes, "sha256:" + new string('0', 64), "9.2.0", allowCandidate: false));
+            Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.0", allowCandidate: false));
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Sharlayan.Tests.Resources {
             byte[] trailing = Encoding.UTF8.GetBytes(Encoding.UTF8.GetString(ReadEmbeddedFixture()) + "{}");
             byte[] latest = Encoding.UTF8.GetBytes("{\"schemaVersion\":2,\"resourceRevision\":\"sha256:" + new string('a', 64) + "\",\"manifest\":\"../manifest.json\",\"fcsCommit\":\"" + new string('b', 40) + "\",\"publishedAt\":\"2026-07-22T00:00:00Z\"}");
 
-            Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(trailing, null, "9.1.2", allowCandidate: true));
+            Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(trailing, null, "9.2.0", allowCandidate: true));
             Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseLatest(latest));
         }
 
@@ -55,17 +55,17 @@ namespace Sharlayan.Tests.Resources {
             JObject wrongType = JObject.Parse(Encoding.UTF8.GetString(ReadEmbeddedFixture()));
             wrongType["schemaVersion"] = "2";
             JObject invalidSemver = JObject.Parse(Encoding.UTF8.GetString(ReadEmbeddedFixture()));
-            invalidSemver["compatibility"]["minimumSharlayanVersion"] = "9.1.2+invalid!";
+            invalidSemver["compatibility"]["minimumSharlayanVersion"] = "9.2.0+invalid!";
 
             Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(
                 Encoding.UTF8.GetBytes(wrongType.ToString(Newtonsoft.Json.Formatting.None)),
                 null,
-                "9.1.2",
+                "9.2.0",
                 allowCandidate: true));
             Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(
                 Encoding.UTF8.GetBytes(invalidSemver.ToString(Newtonsoft.Json.Formatting.None)),
                 null,
-                "9.1.2",
+                "9.2.0",
                 allowCandidate: true));
         }
 
@@ -77,7 +77,7 @@ namespace Sharlayan.Tests.Resources {
             Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(
                 Encoding.UTF8.GetBytes(json.ToString(Newtonsoft.Json.Formatting.None)),
                 null,
-                "9.1.2",
+                "9.2.0",
                 allowCandidate: true));
         }
 
@@ -91,12 +91,12 @@ namespace Sharlayan.Tests.Resources {
             Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(
                 Encoding.UTF8.GetBytes(wrongLengthSource.ToString(Newtonsoft.Json.Formatting.None)),
                 null,
-                "9.1.2",
+                "9.2.0",
                 allowCandidate: true));
             Assert.Throws<InvalidDataException>(() => HermesV2ManifestParser.ParseManifest(
                 Encoding.UTF8.GetBytes(wrongCurrentType.ToString(Newtonsoft.Json.Formatting.None)),
                 null,
-                "9.1.2",
+                "9.2.0",
                 allowCandidate: true));
         }
 
@@ -107,12 +107,12 @@ namespace Sharlayan.Tests.Resources {
             byte[] bytes = Encoding.UTF8.GetBytes(json.ToString(Newtonsoft.Json.Formatting.None));
 
             Assert.Throws<InvalidDataException>(() =>
-                HermesV2ManifestParser.ParseManifest(bytes, null, "9.1.2", allowCandidate: true));
+                HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.0", allowCandidate: true));
         }
 
         [Fact]
         public void MapperKeepsChatAndTalkOnOneManifest() {
-            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(ReadEmbeddedFixture(), null, "9.1.2", allowCandidate: true);
+            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(ReadEmbeddedFixture(), null, "9.2.0", allowCandidate: true);
 
             HermesMappedResources mapped = HermesV2ResourceMapper.Map(manifest);
 
@@ -194,9 +194,12 @@ namespace Sharlayan.Tests.Resources {
             Assert.Equal(1, mapped.BattleTalkLayout.TextIndex);
         }
 
-        internal static byte[] CreateLiveManifest(string minimumVersion = "9.1.2") {
+        internal static byte[] CreateLiveManifest(string minimumVersion = "9.2.0") {
             JObject json = JObject.Parse(Encoding.UTF8.GetString(ReadEmbeddedFixture()));
             json["compatibility"]["minimumSharlayanVersion"] = minimumVersion;
+            if (minimumVersion != "9.2.0") {
+                json["resources"]["battleTalk"].Parent.Remove();
+            }
             json["validation"] = new JObject {
                 ["status"] = "live-verified",
                 ["gameVersion"] = "7.51",

--- a/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
+++ b/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
@@ -139,6 +139,61 @@ namespace Sharlayan.Tests.Resources {
             Assert.Equal(new[] { 0x28 }, mapped.CurrentTalkLayout.AllowedStringTypes);
         }
 
+        [Fact]
+        public void ParserAndMapperAcceptOptionalBattleTalk() {
+            JObject json = JObject.Parse(Encoding.UTF8.GetString(ReadEmbeddedFixture()));
+            json["compatibility"]["minimumSharlayanVersion"] = "9.2.0";
+            json["resources"]["battleTalk"] = new JObject {
+                ["root"] = "framework",
+                ["semantics"] = "currentBattleTalk",
+                ["uiModuleOffset"] = 11112,
+                ["raptureAtkModuleOffset"] = 861808,
+                ["raptureAtkUnitManagerOffset"] = 78880,
+                ["allLoadedUnitsListOffset"] = 26880,
+                ["atkUnitList"] = json["resources"]["currentTalk"]["atkUnitList"].DeepClone(),
+                ["addon"] = new JObject {
+                    ["nameOffset"] = 8,
+                    ["nameCapacity"] = 32,
+                    ["visibilityStateOffset"] = 408,
+                    ["visibilityMask"] = 2097152,
+                    ["readinessOffset"] = 417,
+                    ["readinessMask"] = 1,
+                },
+                ["addonName"] = "_BattleTalk",
+                ["atkArrayDataHolderOffset"] = 7080,
+                ["arrayDataHolder"] = new JObject {
+                    ["numberArrayCountOffset"] = 0,
+                    ["numberArraysOffset"] = 24,
+                    ["stringArrayCountOffset"] = 2,
+                    ["stringArraysOffset"] = 48,
+                },
+                ["arrayData"] = new JObject {
+                    ["sizeOffset"] = 8,
+                    ["updateStateOffset"] = 31,
+                },
+                ["numberValuesOffset"] = 40,
+                ["stringValuesOffset"] = 40,
+                ["numberArrayId"] = 38,
+                ["stringArrayId"] = 35,
+                ["visibleIndex"] = 0,
+                ["nameIndex"] = 0,
+                ["textIndex"] = 1,
+                ["sequenceSemantics"] = "visibilityOrContentGeneration",
+            };
+            byte[] bytes = Encoding.UTF8.GetBytes(json.ToString(Newtonsoft.Json.Formatting.None));
+
+            HermesV2Manifest manifest =
+                HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.0", allowCandidate: true);
+            HermesMappedResources mapped = HermesV2ResourceMapper.Map(manifest);
+
+            Assert.NotNull(mapped.BattleTalkLayout);
+            Assert.Equal("_BattleTalk", mapped.BattleTalkLayout.AddonName);
+            Assert.Equal(38, mapped.BattleTalkLayout.NumberArrayId);
+            Assert.Equal(35, mapped.BattleTalkLayout.StringArrayId);
+            Assert.Equal(0, mapped.BattleTalkLayout.NameIndex);
+            Assert.Equal(1, mapped.BattleTalkLayout.TextIndex);
+        }
+
         internal static byte[] CreateLiveManifest(string minimumVersion = "9.1.2") {
             JObject json = JObject.Parse(Encoding.UTF8.GetString(ReadEmbeddedFixture()));
             json["compatibility"]["minimumSharlayanVersion"] = minimumVersion;

--- a/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
+++ b/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
@@ -20,7 +20,7 @@ namespace Sharlayan.Tests.Resources {
 
             Assert.Equal(2, manifest.SchemaVersion);
             Assert.Equal("ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1", manifest.Source.FcsCommit);
-            Assert.Equal("sha256:065e24246f0707101601d76fd23ce159d26f74f60c0368a589ef4da0a7abb701", HermesV2ManifestParser.CalculateRevision(bytes));
+            Assert.Equal("sha256:88377d75d7031b077962dd391e2885c7c4f536ccead01d07c321b1262a6b0b9b", HermesV2ManifestParser.CalculateRevision(bytes));
         }
 
         [Fact]

--- a/Sharlayan.Tests/Resources/HermesV2ResourceProviderTests.cs
+++ b/Sharlayan.Tests/Resources/HermesV2ResourceProviderTests.cs
@@ -26,7 +26,7 @@ namespace Sharlayan.Tests.Resources {
                     schemaVersion = 2,
                     resourceRevision = revision,
                     manifest = "manifests/" + revision + ".json",
-                    fcsCommit = "8ff04195c4e77ef0b85d15c6fd1c67785378f0fb",
+                    fcsCommit = "ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1",
                     publishedAt = "2026-07-22T00:00:00Z",
                 }));
                 FakeTransport transport = new FakeTransport(
@@ -38,14 +38,14 @@ namespace Sharlayan.Tests.Resources {
                     ResourceCacheDirectory = cacheDirectory,
                 };
 
-                IReadOnlyList<HermesManifestCandidate> remote = await new HermesV2ResourceProvider(configuration, transport, "9.1.2").GetCandidatesAsync(CancellationToken.None);
+                IReadOnlyList<HermesManifestCandidate> remote = await new HermesV2ResourceProvider(configuration, transport, "9.2.0").GetCandidatesAsync(CancellationToken.None);
                 Assert.True(remote[0].Info.Source == ResourceSource.Remote, remote[0].Info.FallbackReason);
                 HermesV2ResourceCache cache = new HermesV2ResourceCache(cacheDirectory);
                 Assert.True(cache.TryReadLatest(out byte[] cachedLatest, out _), remote[0].Info.FallbackReason);
                 HermesLatestPointer cachedPointer = HermesV2ManifestParser.ParseLatest(cachedLatest);
                 Assert.True(cache.TryReadManifest(cachedPointer.ResourceRevision, out byte[] cachedBytes));
-                Assert.NotNull(HermesV2ManifestParser.ParseManifest(cachedBytes, cachedPointer.ResourceRevision, "9.1.2", allowCandidate: false));
-                IReadOnlyList<HermesManifestCandidate> fallback = await new HermesV2ResourceProvider(configuration, new ThrowingTransport(), "9.1.2").GetCandidatesAsync(CancellationToken.None);
+                Assert.NotNull(HermesV2ManifestParser.ParseManifest(cachedBytes, cachedPointer.ResourceRevision, "9.2.0", allowCandidate: false));
+                IReadOnlyList<HermesManifestCandidate> fallback = await new HermesV2ResourceProvider(configuration, new ThrowingTransport(), "9.2.0").GetCandidatesAsync(CancellationToken.None);
 
                 Assert.Equal(revision, remote[0].Info.ResourceRevision);
                 Assert.Equal(ResourceSource.Cache, fallback[0].Info.Source);
@@ -63,7 +63,7 @@ namespace Sharlayan.Tests.Resources {
             SharlayanConfiguration configuration = new SharlayanConfiguration { ResourceMode = ResourceMode.EmbeddedOnly };
             CountingTransport transport = new CountingTransport();
 
-            IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(configuration, transport, "9.1.2").GetCandidatesAsync(CancellationToken.None);
+            IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(configuration, transport, "9.2.0").GetCandidatesAsync(CancellationToken.None);
 
             Assert.Equal(0, transport.CallCount);
             Assert.Single(candidates);
@@ -78,7 +78,7 @@ namespace Sharlayan.Tests.Resources {
             };
             CountingTransport transport = new CountingTransport();
 
-            IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(configuration, transport, "9.1.2").GetCandidatesAsync(CancellationToken.None);
+            IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(configuration, transport, "9.2.0").GetCandidatesAsync(CancellationToken.None);
 
             Assert.Equal(0, transport.CallCount);
             Assert.Single(candidates);
@@ -105,7 +105,7 @@ namespace Sharlayan.Tests.Resources {
                 IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(
                     configuration,
                     new FakeTransport(new HermesHttpResponse(HttpStatusCode.NotModified, Array.Empty<byte>(), "\"v1\"")),
-                    "9.1.2").GetCandidatesAsync(CancellationToken.None);
+                    "9.2.0").GetCandidatesAsync(CancellationToken.None);
 
                 Assert.Equal(ResourceSource.Cache, candidates[0].Info.Source);
                 Assert.Equal(revision, candidates[0].Info.ResourceRevision);
@@ -130,7 +130,7 @@ namespace Sharlayan.Tests.Resources {
                     ResourceCacheDirectory = cacheDirectory,
                 };
 
-                IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(configuration, new ThrowingTransport(), "9.1.2").GetCandidatesAsync(CancellationToken.None);
+                IReadOnlyList<HermesManifestCandidate> candidates = await new HermesV2ResourceProvider(configuration, new ThrowingTransport(), "9.2.0").GetCandidatesAsync(CancellationToken.None);
 
                 Assert.Single(candidates);
                 Assert.Equal(ResourceSource.Embedded, candidates[0].Info.Source);
@@ -163,7 +163,7 @@ namespace Sharlayan.Tests.Resources {
                 schemaVersion = 2,
                 resourceRevision = revision,
                 manifest = "manifests/" + revision + ".json",
-                fcsCommit = "8ff04195c4e77ef0b85d15c6fd1c67785378f0fb",
+                fcsCommit = "ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1",
                 publishedAt = "2026-07-22T00:00:00Z",
             }));
         }

--- a/Sharlayan/MemoryHandler.cs
+++ b/Sharlayan/MemoryHandler.cs
@@ -96,6 +96,8 @@ namespace Sharlayan {
 
         internal CurrentTalkMemoryLayout CurrentTalkLayout { get; private set; }
 
+        internal BattleTalkMemoryLayout BattleTalkLayout { get; private set; }
+
         private List<ProcessModule> _systemModules { get; } = new List<ProcessModule>();
 
         public void Dispose() {
@@ -397,6 +399,7 @@ namespace Sharlayan {
                 this.Structures = mapped.Structures;
                 this.TalkLayout = mapped.TalkLayout;
                 this.CurrentTalkLayout = mapped.CurrentTalkLayout;
+                this.BattleTalkLayout = mapped.BattleTalkLayout;
                 this.Scanner = scanner;
                 this.ResourceInfo = new ResourceInfo(
                     candidate.Info.Source,

--- a/Sharlayan/Models/ReadResults/BattleTalkResult.cs
+++ b/Sharlayan/Models/ReadResults/BattleTalkResult.cs
@@ -1,0 +1,22 @@
+namespace Sharlayan.Models.ReadResults {
+    public sealed class BattleTalkResult {
+        public BattleTalkResult(
+            bool isAvailable,
+            bool isVisible,
+            string name,
+            string text,
+            long sequence) {
+            this.IsAvailable = isAvailable;
+            this.IsVisible = isVisible;
+            this.Name = name ?? string.Empty;
+            this.Text = text ?? string.Empty;
+            this.Sequence = sequence;
+        }
+
+        public bool IsAvailable { get; }
+        public bool IsVisible { get; }
+        public string Name { get; }
+        public string Text { get; }
+        public long Sequence { get; }
+    }
+}

--- a/Sharlayan/Models/Resources/BattleTalkProbeLayout.cs
+++ b/Sharlayan/Models/Resources/BattleTalkProbeLayout.cs
@@ -1,0 +1,132 @@
+namespace Sharlayan.Models.Resources {
+    using System;
+    using System.Collections.Generic;
+
+    internal sealed class BattleTalkProbeLayout {
+        public int SchemaVersion { get; set; }
+        public string FcsCommit { get; set; }
+        public BattleTalkProbeUiLayout Ui { get; set; }
+        public BattleTalkProbeAddonLayout Addon { get; set; }
+        public BattleTalkProbeArrayLayout Arrays { get; set; }
+        public BattleTalkProbeAgentHudLayout AgentHud { get; set; }
+        public HermesUtf8StringLayout Utf8String { get; set; }
+    }
+
+    internal sealed class BattleTalkProbeUiLayout {
+        public int UiModuleOffset { get; set; }
+        public int RaptureAtkModuleOffset { get; set; }
+    }
+
+    internal sealed class BattleTalkProbeAddonLayout {
+        public int RaptureAtkUnitManagerOffset { get; set; }
+        public int AllLoadedUnitsListOffset { get; set; }
+        public HermesAtkUnitListLayout AtkUnitList { get; set; }
+        public HermesAtkUnitBaseLayout AtkUnitBase { get; set; }
+        public HermesAtkValueLayout AtkValue { get; set; }
+        public string BattleTalkAddonName { get; set; }
+    }
+
+    internal sealed class BattleTalkProbeArrayLayout {
+        public int AtkArrayDataHolderOffset { get; set; }
+        public int NumberArrayCountOffset { get; set; }
+        public int NumberArraysOffset { get; set; }
+        public int StringArrayCountOffset { get; set; }
+        public int StringArraysOffset { get; set; }
+        public int ArraySizeOffset { get; set; }
+        public int ArrayUpdateStateOffset { get; set; }
+        public int NumberValuesOffset { get; set; }
+        public int StringValuesOffset { get; set; }
+        public int ManagedStringValuesOffset { get; set; }
+        public int BattleTalkNumberArrayId { get; set; }
+        public int BattleTalkStringArrayId { get; set; }
+    }
+
+    internal sealed class BattleTalkProbeAgentHudLayout {
+        public int AgentModuleOffset { get; set; }
+        public int AgentsOffset { get; set; }
+        public int AgentsCapacity { get; set; }
+        public int AgentEntrySize { get; set; }
+        public int HudAgentId { get; set; }
+        public int QueueOffset { get; set; }
+        public int QueueCapacity { get; set; }
+        public int QueueEntrySize { get; set; }
+        public int IsPendingOffset { get; set; }
+        public int StyleOffset { get; set; }
+        public int NameOffset { get; set; }
+        public int TextOffset { get; set; }
+        public int ImageOffset { get; set; }
+        public int SoundOffset { get; set; }
+        public int EntityIdOffset { get; set; }
+    }
+
+    internal sealed class BattleTalkProbeObservation {
+        internal BattleTalkProbeObservation(
+            BattleTalkProbeAddonObservation addon,
+            BattleTalkProbeNumberArrayObservation numberArray,
+            BattleTalkProbeStringArrayObservation stringArray,
+            IReadOnlyList<BattleTalkProbeQueueSlot> queueSlots,
+            string fingerprint) {
+            this.Addon = addon;
+            this.NumberArray = numberArray;
+            this.StringArray = stringArray;
+            this.QueueSlots = queueSlots;
+            this.Fingerprint = fingerprint;
+        }
+
+        internal BattleTalkProbeAddonObservation Addon { get; }
+        internal BattleTalkProbeNumberArrayObservation NumberArray { get; }
+        internal BattleTalkProbeStringArrayObservation StringArray { get; }
+        internal IReadOnlyList<BattleTalkProbeQueueSlot> QueueSlots { get; }
+        internal string Fingerprint { get; }
+    }
+
+    internal sealed class BattleTalkProbeAddonObservation {
+        internal bool IsReadable { get; set; }
+        internal bool IsFound { get; set; }
+        internal bool IsVisible { get; set; }
+        internal bool IsReady { get; set; }
+        internal int AtkValueCount { get; set; }
+        internal IReadOnlyDictionary<int, BattleTalkProbeString> Strings { get; set; } =
+            new Dictionary<int, BattleTalkProbeString>();
+    }
+
+    internal sealed class BattleTalkProbeNumberArrayObservation {
+        internal bool IsReadable { get; set; }
+        internal byte UpdateState { get; set; }
+        internal IReadOnlyList<int> Values { get; set; } = new int[0];
+    }
+
+    internal sealed class BattleTalkProbeStringArrayObservation {
+        internal bool IsReadable { get; set; }
+        internal byte UpdateState { get; set; }
+        internal IReadOnlyDictionary<int, BattleTalkProbeString> Values { get; set; } =
+            new Dictionary<int, BattleTalkProbeString>();
+    }
+
+    internal sealed class BattleTalkProbeQueueSlot {
+        internal int Index { get; set; }
+        internal bool IsReadable { get; set; }
+        internal bool IsPending { get; set; }
+        internal byte Style { get; set; }
+        internal BattleTalkProbeString Name { get; set; }
+        internal BattleTalkProbeString Text { get; set; }
+        internal uint Image { get; set; }
+        internal int Sound { get; set; }
+        internal uint EntityId { get; set; }
+    }
+
+    internal sealed class BattleTalkProbeString {
+        internal static BattleTalkProbeString Empty { get; } =
+            new BattleTalkProbeString(IntPtr.Zero, 0, string.Empty);
+
+        internal BattleTalkProbeString(IntPtr pointer, int utf8Length, string hash) {
+            this.Pointer = pointer;
+            this.Utf8Length = utf8Length;
+            this.Hash = hash;
+        }
+
+        internal IntPtr Pointer { get; }
+        internal int Utf8Length { get; }
+        internal string Hash { get; }
+    }
+}

--- a/Sharlayan/Models/Resources/HermesV2Manifest.cs
+++ b/Sharlayan/Models/Resources/HermesV2Manifest.cs
@@ -57,6 +57,7 @@ namespace Sharlayan.Models.Resources {
         [JsonProperty("chatLog", Required = Required.Always)] public HermesChatLogResource ChatLog { get; set; }
         [JsonProperty("talk", Required = Required.Always)] public HermesTalkResource Talk { get; set; }
         [JsonProperty("currentTalk", Required = Required.Always)] public HermesCurrentTalkResource CurrentTalk { get; set; }
+        [JsonProperty("battleTalk")] public HermesBattleTalkResource BattleTalk { get; set; }
     }
 
     internal sealed class HermesChatLogResource {
@@ -97,6 +98,29 @@ namespace Sharlayan.Models.Resources {
         [JsonProperty("nameValueIndex", Required = Required.Always)] public int NameValueIndex { get; set; }
     }
 
+    internal sealed class HermesBattleTalkResource {
+        [JsonProperty("root", Required = Required.Always)] public string Root { get; set; }
+        [JsonProperty("semantics", Required = Required.Always)] public string Semantics { get; set; }
+        [JsonProperty("uiModuleOffset", Required = Required.Always)] public int UiModuleOffset { get; set; }
+        [JsonProperty("raptureAtkModuleOffset", Required = Required.Always)] public int RaptureAtkModuleOffset { get; set; }
+        [JsonProperty("raptureAtkUnitManagerOffset", Required = Required.Always)] public int RaptureAtkUnitManagerOffset { get; set; }
+        [JsonProperty("allLoadedUnitsListOffset", Required = Required.Always)] public int AllLoadedUnitsListOffset { get; set; }
+        [JsonProperty("atkUnitList", Required = Required.Always)] public HermesAtkUnitListLayout AtkUnitList { get; set; }
+        [JsonProperty("addon", Required = Required.Always)] public HermesAddonVisibilityLayout Addon { get; set; }
+        [JsonProperty("addonName", Required = Required.Always)] public string AddonName { get; set; }
+        [JsonProperty("atkArrayDataHolderOffset", Required = Required.Always)] public int AtkArrayDataHolderOffset { get; set; }
+        [JsonProperty("arrayDataHolder", Required = Required.Always)] public HermesAtkArrayDataHolderLayout ArrayDataHolder { get; set; }
+        [JsonProperty("arrayData", Required = Required.Always)] public HermesAtkArrayDataLayout ArrayData { get; set; }
+        [JsonProperty("numberValuesOffset", Required = Required.Always)] public int NumberValuesOffset { get; set; }
+        [JsonProperty("stringValuesOffset", Required = Required.Always)] public int StringValuesOffset { get; set; }
+        [JsonProperty("numberArrayId", Required = Required.Always)] public int NumberArrayId { get; set; }
+        [JsonProperty("stringArrayId", Required = Required.Always)] public int StringArrayId { get; set; }
+        [JsonProperty("visibleIndex", Required = Required.Always)] public int VisibleIndex { get; set; }
+        [JsonProperty("nameIndex", Required = Required.Always)] public int NameIndex { get; set; }
+        [JsonProperty("textIndex", Required = Required.Always)] public int TextIndex { get; set; }
+        [JsonProperty("sequenceSemantics", Required = Required.Always)] public string SequenceSemantics { get; set; }
+    }
+
     internal sealed class HermesAtkUnitListLayout {
         [JsonProperty("entriesOffset", Required = Required.Always)] public int EntriesOffset { get; set; }
         [JsonProperty("countOffset", Required = Required.Always)] public int CountOffset { get; set; }
@@ -113,6 +137,27 @@ namespace Sharlayan.Models.Resources {
         [JsonProperty("readinessMask", Required = Required.Always)] public uint ReadinessMask { get; set; }
         [JsonProperty("atkValuesPointerOffset", Required = Required.Always)] public int AtkValuesPointerOffset { get; set; }
         [JsonProperty("atkValuesCountOffset", Required = Required.Always)] public int AtkValuesCountOffset { get; set; }
+    }
+
+    internal sealed class HermesAddonVisibilityLayout {
+        [JsonProperty("nameOffset", Required = Required.Always)] public int NameOffset { get; set; }
+        [JsonProperty("nameCapacity", Required = Required.Always)] public int NameCapacity { get; set; }
+        [JsonProperty("visibilityStateOffset", Required = Required.Always)] public int VisibilityStateOffset { get; set; }
+        [JsonProperty("visibilityMask", Required = Required.Always)] public uint VisibilityMask { get; set; }
+        [JsonProperty("readinessOffset", Required = Required.Always)] public int ReadinessOffset { get; set; }
+        [JsonProperty("readinessMask", Required = Required.Always)] public uint ReadinessMask { get; set; }
+    }
+
+    internal sealed class HermesAtkArrayDataHolderLayout {
+        [JsonProperty("numberArrayCountOffset", Required = Required.Always)] public int NumberArrayCountOffset { get; set; }
+        [JsonProperty("numberArraysOffset", Required = Required.Always)] public int NumberArraysOffset { get; set; }
+        [JsonProperty("stringArrayCountOffset", Required = Required.Always)] public int StringArrayCountOffset { get; set; }
+        [JsonProperty("stringArraysOffset", Required = Required.Always)] public int StringArraysOffset { get; set; }
+    }
+
+    internal sealed class HermesAtkArrayDataLayout {
+        [JsonProperty("sizeOffset", Required = Required.Always)] public int SizeOffset { get; set; }
+        [JsonProperty("updateStateOffset", Required = Required.Always)] public int UpdateStateOffset { get; set; }
     }
 
     internal sealed class HermesAtkValueLayout {

--- a/Sharlayan/Reader.BattleTalk.cs
+++ b/Sharlayan/Reader.BattleTalk.cs
@@ -1,0 +1,97 @@
+namespace Sharlayan {
+    using System;
+
+    using Sharlayan.Models.ReadResults;
+    using Sharlayan.Resources;
+
+    public partial class Reader {
+        private readonly object _battleTalkLock = new object();
+        private readonly BattleTalkSequenceTracker _battleTalkTracker =
+            new BattleTalkSequenceTracker();
+
+        public bool CanGetBattleTalk() {
+            return this._memoryHandler != null
+                   && this._memoryHandler.BattleTalkLayout != null
+                   && this._memoryHandler.Scanner.Locations.ContainsKey(
+                       Signatures.CURRENT_TALK_UI_MODULE_POINTER_KEY);
+        }
+
+        public BattleTalkResult GetBattleTalk() {
+            if (!this.CanGetBattleTalk() || !this._memoryHandler.IsAttached) {
+                return new BattleTalkResult(
+                    false,
+                    false,
+                    string.Empty,
+                    string.Empty,
+                    this._battleTalkTracker.Sequence);
+            }
+
+            lock (this._battleTalkLock) {
+                try {
+                    IntPtr uiModulePointerAddress =
+                        this._memoryHandler.Scanner.Locations[
+                            Signatures.CURRENT_TALK_UI_MODULE_POINTER_KEY];
+                    BattleTalkMemoryObservation observation = BattleTalkMemoryReader.Read(
+                        this._memoryHandler.Peek,
+                        uiModulePointerAddress,
+                        this._memoryHandler.BattleTalkLayout);
+                    return this._battleTalkTracker.Observe(observation);
+                }
+                catch (Exception exception) {
+                    this._memoryHandler.RaiseException(Logger, exception);
+                    return new BattleTalkResult(
+                        false,
+                        false,
+                        string.Empty,
+                        string.Empty,
+                        this._battleTalkTracker.Sequence);
+                }
+            }
+        }
+    }
+
+    internal sealed class BattleTalkSequenceTracker {
+        private bool wasVisible;
+        private string name = string.Empty;
+        private string text = string.Empty;
+
+        internal long Sequence { get; private set; }
+
+        internal BattleTalkResult Observe(BattleTalkMemoryObservation observation) {
+            if (!observation.IsAvailable) {
+                return new BattleTalkResult(
+                    false,
+                    false,
+                    string.Empty,
+                    string.Empty,
+                    this.Sequence);
+            }
+
+            if (!observation.IsVisible) {
+                this.wasVisible = false;
+                return new BattleTalkResult(
+                    true,
+                    false,
+                    string.Empty,
+                    string.Empty,
+                    this.Sequence);
+            }
+
+            if (!this.wasVisible
+                || !string.Equals(this.name, observation.Name, StringComparison.Ordinal)
+                || !string.Equals(this.text, observation.Text, StringComparison.Ordinal)) {
+                this.Sequence = checked(this.Sequence + 1);
+            }
+
+            this.wasVisible = true;
+            this.name = observation.Name;
+            this.text = observation.Text;
+            return new BattleTalkResult(
+                true,
+                true,
+                observation.Name,
+                observation.Text,
+                this.Sequence);
+        }
+    }
+}

--- a/Sharlayan/Resources/BattleTalkContractProbe.cs
+++ b/Sharlayan/Resources/BattleTalkContractProbe.cs
@@ -1,0 +1,546 @@
+namespace Sharlayan.Resources {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    using Sharlayan.Models.Resources;
+
+    internal static class BattleTalkContractProbe {
+        private const int MaximumArraySize = 4096;
+        private const int MaximumStringBytes = 65536;
+        private static readonly Encoding StrictUtf8 = new UTF8Encoding(false, true);
+
+        internal static BattleTalkProbeObservation Read(
+            MemoryPeek peek,
+            IntPtr uiModulePointerAddress,
+            BattleTalkProbeLayout layout) {
+            if (peek == null) throw new ArgumentNullException(nameof(peek));
+            if (layout == null) throw new ArgumentNullException(nameof(layout));
+            Validate(layout);
+
+            IntPtr uiModule;
+            IntPtr raptureAtkModule;
+            if (!TryReadPointer(peek, uiModulePointerAddress, out uiModule)
+                || uiModule == IntPtr.Zero
+                || !TryAdd(uiModule, layout.Ui.RaptureAtkModuleOffset, out raptureAtkModule)) {
+                return EmptyObservation();
+            }
+
+            BattleTalkProbeAddonObservation addon = ReadAddon(peek, raptureAtkModule, layout.Addon);
+            BattleTalkProbeNumberArrayObservation numberArray = ReadNumberArray(peek, raptureAtkModule, layout.Arrays);
+            BattleTalkProbeStringArrayObservation stringArray = ReadStringArray(peek, raptureAtkModule, layout.Arrays);
+            IReadOnlyList<BattleTalkProbeQueueSlot> queue = ReadQueue(peek, raptureAtkModule, layout.AgentHud, layout.Utf8String);
+            string fingerprint = CalculateFingerprint(addon, numberArray, stringArray, queue);
+            return new BattleTalkProbeObservation(addon, numberArray, stringArray, queue, fingerprint);
+        }
+
+        private static BattleTalkProbeAddonObservation ReadAddon(
+            MemoryPeek peek,
+            IntPtr raptureAtkModule,
+            BattleTalkProbeAddonLayout layout) {
+            BattleTalkProbeAddonObservation result = new BattleTalkProbeAddonObservation();
+            IntPtr manager;
+            IntPtr list;
+            IntPtr countAddress;
+            ushort count;
+            IntPtr entries;
+            if (!TryAdd(raptureAtkModule, layout.RaptureAtkUnitManagerOffset, out manager)
+                || !TryAdd(manager, layout.AllLoadedUnitsListOffset, out list)
+                || !TryAdd(list, layout.AtkUnitList.CountOffset, out countAddress)
+                || !TryReadUInt16(peek, countAddress, out count)
+                || count > layout.AtkUnitList.Capacity
+                || !TryAdd(list, layout.AtkUnitList.EntriesOffset, out entries)) {
+                return result;
+            }
+
+            result.IsReadable = true;
+            for (int index = 0; index < count; index++) {
+                IntPtr entry;
+                IntPtr addon;
+                if (!TryAdd(entries, (long) index * layout.AtkUnitList.EntrySize, out entry)
+                    || !TryReadPointer(peek, entry, out addon)) {
+                    result.IsReadable = false;
+                    return result;
+                }
+
+                if (addon == IntPtr.Zero || !IsAddonNamed(peek, addon, layout.AtkUnitBase, layout.BattleTalkAddonName)) {
+                    continue;
+                }
+
+                result.IsFound = true;
+                uint visibility;
+                byte readiness;
+                IntPtr visibilityAddress;
+                IntPtr readinessAddress;
+                IntPtr countValueAddress;
+                ushort atkValueCount;
+                IntPtr valuesPointerAddress;
+                IntPtr values;
+                if (!TryAdd(addon, layout.AtkUnitBase.VisibilityStateOffset, out visibilityAddress)
+                    || !TryReadUInt32(peek, visibilityAddress, out visibility)
+                    || !TryAdd(addon, layout.AtkUnitBase.ReadinessOffset, out readinessAddress)
+                    || !TryReadByte(peek, readinessAddress, out readiness)
+                    || !TryAdd(addon, layout.AtkUnitBase.AtkValuesCountOffset, out countValueAddress)
+                    || !TryReadUInt16(peek, countValueAddress, out atkValueCount)
+                    || atkValueCount > MaximumArraySize
+                    || !TryAdd(addon, layout.AtkUnitBase.AtkValuesPointerOffset, out valuesPointerAddress)
+                    || !TryReadPointer(peek, valuesPointerAddress, out values)) {
+                    result.IsReadable = false;
+                    return result;
+                }
+
+                result.IsVisible = (visibility & layout.AtkUnitBase.VisibilityMask) != 0;
+                result.IsReady = (readiness & layout.AtkUnitBase.ReadinessMask) != 0;
+                result.AtkValueCount = atkValueCount;
+                Dictionary<int, BattleTalkProbeString> strings = new Dictionary<int, BattleTalkProbeString>();
+                int captureCount = Math.Min((int) atkValueCount, 128);
+                for (int valueIndex = 0; valueIndex < captureCount; valueIndex++) {
+                    IntPtr valueAddress;
+                    IntPtr typeAddress;
+                    int type;
+                    IntPtr pointerAddress;
+                    IntPtr pointer;
+                    if (!TryAdd(values, (long) valueIndex * layout.AtkValue.Size, out valueAddress)
+                        || !TryAdd(valueAddress, layout.AtkValue.TypeOffset, out typeAddress)
+                        || !TryReadInt32(peek, typeAddress, out type)
+                        || !layout.AtkValue.AllowedStringTypes.Contains(type)
+                        || !TryAdd(valueAddress, layout.AtkValue.ValueOffset, out pointerAddress)
+                        || !TryReadPointer(peek, pointerAddress, out pointer)
+                        || pointer == IntPtr.Zero) {
+                        continue;
+                    }
+
+                    BattleTalkProbeString value;
+                    if (TryReadCString(peek, pointer, out value)) {
+                        strings[valueIndex] = value;
+                    }
+                }
+
+                result.Strings = strings;
+                return result;
+            }
+
+            return result;
+        }
+
+        private static BattleTalkProbeNumberArrayObservation ReadNumberArray(
+            MemoryPeek peek,
+            IntPtr raptureAtkModule,
+            BattleTalkProbeArrayLayout layout) {
+            BattleTalkProbeNumberArrayObservation result = new BattleTalkProbeNumberArrayObservation();
+            IntPtr holder;
+            short count;
+            IntPtr arrays;
+            IntPtr data;
+            int size;
+            byte updateState;
+            IntPtr values;
+            if (!TryAdd(raptureAtkModule, layout.AtkArrayDataHolderOffset, out holder)
+                || !TryReadInt16(peek, holder, layout.NumberArrayCountOffset, out count)
+                || count <= layout.BattleTalkNumberArrayId
+                || !TryReadPointerAt(peek, holder, layout.NumberArraysOffset, out arrays)
+                || !TryReadPointerAt(peek, arrays, (long) layout.BattleTalkNumberArrayId * 8, out data)
+                || data == IntPtr.Zero
+                || !TryReadInt32At(peek, data, layout.ArraySizeOffset, out size)
+                || size < 0
+                || size > MaximumArraySize
+                || !TryReadByteAt(peek, data, layout.ArrayUpdateStateOffset, out updateState)
+                || !TryReadPointerAt(peek, data, layout.NumberValuesOffset, out values)) {
+                return result;
+            }
+
+            byte[] bytes = new byte[checked(size * 4)];
+            if (size > 0 && (values == IntPtr.Zero || !peek(values, bytes, bytes.Length))) {
+                return result;
+            }
+
+            int[] integers = new int[size];
+            for (int index = 0; index < size; index++) {
+                integers[index] = BitConverter.ToInt32(bytes, index * 4);
+            }
+
+            result.IsReadable = true;
+            result.UpdateState = updateState;
+            result.Values = integers;
+            return result;
+        }
+
+        private static BattleTalkProbeStringArrayObservation ReadStringArray(
+            MemoryPeek peek,
+            IntPtr raptureAtkModule,
+            BattleTalkProbeArrayLayout layout) {
+            BattleTalkProbeStringArrayObservation result = new BattleTalkProbeStringArrayObservation();
+            IntPtr holder;
+            short count;
+            IntPtr arrays;
+            IntPtr data;
+            int size;
+            byte updateState;
+            IntPtr values;
+            if (!TryAdd(raptureAtkModule, layout.AtkArrayDataHolderOffset, out holder)
+                || !TryReadInt16(peek, holder, layout.StringArrayCountOffset, out count)
+                || count <= layout.BattleTalkStringArrayId
+                || !TryReadPointerAt(peek, holder, layout.StringArraysOffset, out arrays)
+                || !TryReadPointerAt(peek, arrays, (long) layout.BattleTalkStringArrayId * 8, out data)
+                || data == IntPtr.Zero
+                || !TryReadInt32At(peek, data, layout.ArraySizeOffset, out size)
+                || size < 0
+                || size > MaximumArraySize
+                || !TryReadByteAt(peek, data, layout.ArrayUpdateStateOffset, out updateState)
+                || !TryReadPointerAt(peek, data, layout.StringValuesOffset, out values)) {
+                return result;
+            }
+
+            Dictionary<int, BattleTalkProbeString> strings = new Dictionary<int, BattleTalkProbeString>();
+            for (int index = 0; index < size; index++) {
+                IntPtr pointer;
+                if (!TryReadPointerAt(peek, values, (long) index * 8, out pointer)) {
+                    return result;
+                }
+
+                BattleTalkProbeString value;
+                if (pointer != IntPtr.Zero && TryReadCString(peek, pointer, out value)) {
+                    strings[index] = value;
+                }
+            }
+
+            result.IsReadable = true;
+            result.UpdateState = updateState;
+            result.Values = strings;
+            return result;
+        }
+
+        private static IReadOnlyList<BattleTalkProbeQueueSlot> ReadQueue(
+            MemoryPeek peek,
+            IntPtr raptureAtkModule,
+            BattleTalkProbeAgentHudLayout layout,
+            HermesUtf8StringLayout utf8String) {
+            List<BattleTalkProbeQueueSlot> slots = new List<BattleTalkProbeQueueSlot>();
+            IntPtr agentModule;
+            IntPtr agents;
+            IntPtr hud;
+            IntPtr queue;
+            if (layout.HudAgentId < 0
+                || layout.HudAgentId >= layout.AgentsCapacity
+                || !TryAdd(raptureAtkModule, layout.AgentModuleOffset, out agentModule)
+                || !TryAdd(agentModule, layout.AgentsOffset, out agents)
+                || !TryReadPointerAt(peek, agents, (long) layout.HudAgentId * layout.AgentEntrySize, out hud)
+                || hud == IntPtr.Zero
+                || !TryAdd(hud, layout.QueueOffset, out queue)) {
+                return slots;
+            }
+
+            for (int index = 0; index < layout.QueueCapacity; index++) {
+                BattleTalkProbeQueueSlot slot = new BattleTalkProbeQueueSlot { Index = index };
+                IntPtr entry;
+                bool pending;
+                byte style;
+                uint image;
+                int sound;
+                uint entity;
+                BattleTalkProbeString name;
+                BattleTalkProbeString text;
+                if (TryAdd(queue, (long) index * layout.QueueEntrySize, out entry)
+                    && TryReadBooleanAt(peek, entry, layout.IsPendingOffset, out pending)
+                    && TryReadByteAt(peek, entry, layout.StyleOffset, out style)
+                    && TryReadUtf8StringAt(peek, entry, layout.NameOffset, utf8String, out name)
+                    && TryReadUtf8StringAt(peek, entry, layout.TextOffset, utf8String, out text)
+                    && TryReadUInt32At(peek, entry, layout.ImageOffset, out image)
+                    && TryReadInt32At(peek, entry, layout.SoundOffset, out sound)
+                    && TryReadUInt32At(peek, entry, layout.EntityIdOffset, out entity)) {
+                    slot.IsReadable = true;
+                    slot.IsPending = pending;
+                    slot.Style = style;
+                    slot.Name = name;
+                    slot.Text = text;
+                    slot.Image = image;
+                    slot.Sound = sound;
+                    slot.EntityId = entity;
+                }
+
+                slots.Add(slot);
+            }
+
+            return slots;
+        }
+
+        private static bool TryReadUtf8StringAt(
+            MemoryPeek peek,
+            IntPtr entry,
+            int offset,
+            HermesUtf8StringLayout layout,
+            out BattleTalkProbeString value) {
+            value = BattleTalkProbeString.Empty;
+            IntPtr address;
+            IntPtr pointer;
+            long used;
+            if (!TryAdd(entry, offset, out address)
+                || !TryReadPointerAt(peek, address, layout.StringPointerOffset, out pointer)
+                || !TryReadInt64At(peek, address, layout.BufferUsedOffset, out used)) {
+                return false;
+            }
+
+            if (used == 0 && pointer == IntPtr.Zero) {
+                value = BattleTalkProbeString.Empty;
+                return true;
+            }
+
+            if (used < 1 || used > MaximumStringBytes + 1 || pointer == IntPtr.Zero) return false;
+
+            int byteCount = checked((int) used);
+            byte[] bytes = new byte[byteCount];
+            if (!peek(pointer, bytes, byteCount) || bytes[byteCount - 1] != 0) {
+                return false;
+            }
+
+            return TryCreateString(pointer, bytes, byteCount - 1, out value);
+        }
+
+        private static bool TryReadCString(MemoryPeek peek, IntPtr pointer, out BattleTalkProbeString value) {
+            value = BattleTalkProbeString.Empty;
+            List<byte> bytes = new List<byte>();
+            byte[] chunk = new byte[256];
+            for (int offset = 0; offset < MaximumStringBytes; offset += chunk.Length) {
+                IntPtr address;
+                int count = Math.Min(chunk.Length, MaximumStringBytes - offset);
+                if (!TryAdd(pointer, offset, out address) || !peek(address, chunk, count)) {
+                    return false;
+                }
+
+                for (int index = 0; index < count; index++) {
+                    if (chunk[index] == 0) {
+                        return TryCreateString(pointer, bytes.ToArray(), bytes.Count, out value);
+                    }
+
+                    bytes.Add(chunk[index]);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryCreateString(
+            IntPtr pointer,
+            byte[] bytes,
+            int count,
+            out BattleTalkProbeString value) {
+            value = BattleTalkProbeString.Empty;
+            try {
+                StrictUtf8.GetString(bytes, 0, count);
+                string hash = ToLowerHex(SHA256.Create().ComputeHash(bytes, 0, count))
+                    .Substring(0, 16);
+                value = new BattleTalkProbeString(pointer, count, hash);
+                return true;
+            }
+            catch (DecoderFallbackException) {
+                return false;
+            }
+        }
+
+        private static bool IsAddonNamed(
+            MemoryPeek peek,
+            IntPtr addon,
+            HermesAtkUnitBaseLayout layout,
+            string expectedName) {
+            IntPtr address;
+            if (!TryAdd(addon, layout.NameOffset, out address)) return false;
+            byte[] bytes = new byte[layout.NameCapacity];
+            if (!peek(address, bytes, bytes.Length)) return false;
+            byte[] expected = Encoding.ASCII.GetBytes(expectedName);
+            if (expected.Length >= bytes.Length || bytes[expected.Length] != 0) return false;
+            for (int index = 0; index < expected.Length; index++) {
+                if (bytes[index] != expected[index]) return false;
+            }
+
+            return true;
+        }
+
+        private static string CalculateFingerprint(
+            BattleTalkProbeAddonObservation addon,
+            BattleTalkProbeNumberArrayObservation number,
+            BattleTalkProbeStringArrayObservation strings,
+            IReadOnlyList<BattleTalkProbeQueueSlot> queue) {
+            StringBuilder builder = new StringBuilder();
+            builder.Append(addon.IsReadable).Append('|').Append(addon.IsFound).Append('|')
+                .Append(addon.IsVisible).Append('|').Append(addon.IsReady).Append('|')
+                .Append(addon.AtkValueCount);
+            AppendStrings(builder, addon.Strings);
+            builder.Append('|').Append(number.IsReadable).Append('|').Append(number.UpdateState);
+            foreach (int item in number.Values) builder.Append(',').Append(item);
+            builder.Append('|').Append(strings.IsReadable).Append('|').Append(strings.UpdateState);
+            AppendStrings(builder, strings.Values);
+            foreach (BattleTalkProbeQueueSlot slot in queue) {
+                builder.Append('|').Append(slot.Index).Append(':').Append(slot.IsReadable).Append(':')
+                    .Append(slot.IsPending).Append(':').Append(slot.Style).Append(':')
+                    .Append(slot.Name?.Hash).Append(':').Append(slot.Text?.Hash).Append(':')
+                    .Append(slot.Image).Append(':').Append(slot.Sound).Append(':').Append(slot.EntityId);
+            }
+
+            byte[] bytes = Encoding.UTF8.GetBytes(builder.ToString());
+            return ToLowerHex(SHA256.Create().ComputeHash(bytes));
+        }
+
+        private static string ToLowerHex(byte[] bytes) {
+            return BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static void AppendStrings(
+            StringBuilder builder,
+            IReadOnlyDictionary<int, BattleTalkProbeString> strings) {
+            foreach (KeyValuePair<int, BattleTalkProbeString> pair in strings) {
+                builder.Append('|').Append(pair.Key).Append(':').Append(pair.Value.Pointer.ToInt64())
+                    .Append(':').Append(pair.Value.Utf8Length).Append(':').Append(pair.Value.Hash);
+            }
+        }
+
+        private static BattleTalkProbeObservation EmptyObservation() {
+            BattleTalkProbeAddonObservation addon = new BattleTalkProbeAddonObservation();
+            BattleTalkProbeNumberArrayObservation number = new BattleTalkProbeNumberArrayObservation();
+            BattleTalkProbeStringArrayObservation strings = new BattleTalkProbeStringArrayObservation();
+            return new BattleTalkProbeObservation(addon, number, strings, new BattleTalkProbeQueueSlot[0], string.Empty);
+        }
+
+        private static void Validate(BattleTalkProbeLayout layout) {
+            if (layout.SchemaVersion != 1
+                || layout.Ui == null
+                || layout.Addon == null
+                || layout.Arrays == null
+                || layout.AgentHud == null
+                || layout.Utf8String == null
+                || layout.Addon.AtkUnitList == null
+                || layout.Addon.AtkUnitBase == null
+                || layout.Addon.AtkValue == null
+                || layout.Addon.AtkValue.AllowedStringTypes == null
+                || layout.Addon.AtkUnitList.Capacity <= 0
+                || layout.Addon.AtkUnitList.Capacity > MaximumArraySize
+                || layout.AgentHud.QueueCapacity <= 0
+                || layout.AgentHud.QueueCapacity > 64
+                || layout.AgentHud.QueueEntrySize <= 0) {
+                throw new InvalidDataException("BattleTalk probe layout is invalid.");
+            }
+        }
+
+        private static bool TryAdd(IntPtr address, long offset, out IntPtr result) {
+            try {
+                result = new IntPtr(checked(address.ToInt64() + offset));
+                return true;
+            }
+            catch (OverflowException) {
+                result = IntPtr.Zero;
+                return false;
+            }
+        }
+
+        private static bool TryReadPointer(MemoryPeek peek, IntPtr address, out IntPtr value) {
+            byte[] bytes = new byte[8];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = IntPtr.Zero;
+                return false;
+            }
+
+            value = new IntPtr(BitConverter.ToInt64(bytes, 0));
+            return true;
+        }
+
+        private static bool TryReadPointerAt(MemoryPeek peek, IntPtr address, long offset, out IntPtr value) {
+            IntPtr target;
+            value = IntPtr.Zero;
+            return TryAdd(address, offset, out target) && TryReadPointer(peek, target, out value);
+        }
+
+        private static bool TryReadBooleanAt(MemoryPeek peek, IntPtr address, long offset, out bool value) {
+            byte raw;
+            bool success = TryReadByteAt(peek, address, offset, out raw);
+            value = raw != 0;
+            return success;
+        }
+
+        private static bool TryReadByte(MemoryPeek peek, IntPtr address, out byte value) {
+            byte[] bytes = new byte[1];
+            if (!peek(address, bytes, 1)) {
+                value = 0;
+                return false;
+            }
+
+            value = bytes[0];
+            return true;
+        }
+
+        private static bool TryReadByteAt(MemoryPeek peek, IntPtr address, long offset, out byte value) {
+            IntPtr target;
+            value = 0;
+            return TryAdd(address, offset, out target) && TryReadByte(peek, target, out value);
+        }
+
+        private static bool TryReadInt16(MemoryPeek peek, IntPtr address, long offset, out short value) {
+            IntPtr target;
+            byte[] bytes = new byte[2];
+            if (!TryAdd(address, offset, out target) || !peek(target, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToInt16(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadUInt16(MemoryPeek peek, IntPtr address, out ushort value) {
+            byte[] bytes = new byte[2];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToUInt16(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadInt32(MemoryPeek peek, IntPtr address, out int value) {
+            byte[] bytes = new byte[4];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToInt32(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadInt32At(MemoryPeek peek, IntPtr address, long offset, out int value) {
+            IntPtr target;
+            value = 0;
+            return TryAdd(address, offset, out target) && TryReadInt32(peek, target, out value);
+        }
+
+        private static bool TryReadUInt32(MemoryPeek peek, IntPtr address, out uint value) {
+            byte[] bytes = new byte[4];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToUInt32(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadUInt32At(MemoryPeek peek, IntPtr address, long offset, out uint value) {
+            IntPtr target;
+            value = 0;
+            return TryAdd(address, offset, out target) && TryReadUInt32(peek, target, out value);
+        }
+
+        private static bool TryReadInt64At(MemoryPeek peek, IntPtr address, long offset, out long value) {
+            IntPtr target;
+            byte[] bytes = new byte[8];
+            if (!TryAdd(address, offset, out target) || !peek(target, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToInt64(bytes, 0);
+            return true;
+        }
+    }
+}

--- a/Sharlayan/Resources/BattleTalkMemoryReader.cs
+++ b/Sharlayan/Resources/BattleTalkMemoryReader.cs
@@ -1,0 +1,527 @@
+namespace Sharlayan.Resources {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    internal sealed class BattleTalkMemoryObservation {
+        internal BattleTalkMemoryObservation(bool isAvailable, bool isVisible, string name, string text) {
+            this.IsAvailable = isAvailable;
+            this.IsVisible = isVisible;
+            this.Name = name ?? string.Empty;
+            this.Text = text ?? string.Empty;
+        }
+
+        internal bool IsAvailable { get; }
+        internal bool IsVisible { get; }
+        internal string Name { get; }
+        internal string Text { get; }
+
+        internal static BattleTalkMemoryObservation Hidden { get; } =
+            new BattleTalkMemoryObservation(true, false, string.Empty, string.Empty);
+
+        internal static BattleTalkMemoryObservation Unavailable { get; } =
+            new BattleTalkMemoryObservation(false, false, string.Empty, string.Empty);
+    }
+
+    internal static class BattleTalkMemoryReader {
+        private const int MaximumArraySize = 4096;
+        private const int MaximumStringBytes = 65536;
+        private const int StringChunkSize = 256;
+        private static readonly Encoding StrictUtf8 = new UTF8Encoding(false, true);
+
+        internal static BattleTalkMemoryObservation Read(
+            MemoryPeek peek,
+            IntPtr uiModulePointerAddress,
+            BattleTalkMemoryLayout layout) {
+            if (peek == null || uiModulePointerAddress == IntPtr.Zero || layout == null) {
+                return BattleTalkMemoryObservation.Unavailable;
+            }
+
+            for (int attempt = 0; attempt < 2; attempt++) {
+                Snapshot before;
+                Snapshot after;
+                Snapshot final;
+                if (!TryCapture(peek, uiModulePointerAddress, layout, out before)) continue;
+                if (!before.IsFound) {
+                    if (TryCapture(peek, uiModulePointerAddress, layout, out after)
+                        && before.Equals(after)) {
+                        return BattleTalkMemoryObservation.Hidden;
+                    }
+
+                    continue;
+                }
+
+                if (!before.IsReady) continue;
+                if (!before.IsVisible) {
+                    if (TryCapture(peek, uiModulePointerAddress, layout, out after)
+                        && before.Equals(after)) {
+                        return BattleTalkMemoryObservation.Hidden;
+                    }
+
+                    continue;
+                }
+
+                byte[] name;
+                byte[] text;
+                byte[] stableName;
+                byte[] stableText;
+                if (!TryReadNullTerminated(peek, before.NamePointer, out name)
+                    || !TryReadNullTerminated(peek, before.TextPointer, out text)
+                    || !TryCapture(peek, uiModulePointerAddress, layout, out after)
+                    || !before.Equals(after)
+                    || !TryReadNullTerminated(peek, after.NamePointer, out stableName)
+                    || !TryReadNullTerminated(peek, after.TextPointer, out stableText)
+                    || !BytesEqual(name, stableName)
+                    || !BytesEqual(text, stableText)
+                    || !TryCapture(peek, uiModulePointerAddress, layout, out final)
+                    || !after.Equals(final)) {
+                    continue;
+                }
+
+                try {
+                    return new BattleTalkMemoryObservation(
+                        true,
+                        true,
+                        StrictUtf8.GetString(name),
+                        StrictUtf8.GetString(text));
+                }
+                catch (DecoderFallbackException) {
+                    return BattleTalkMemoryObservation.Unavailable;
+                }
+            }
+
+            return BattleTalkMemoryObservation.Unavailable;
+        }
+
+        private static bool TryCapture(
+            MemoryPeek peek,
+            IntPtr uiModulePointerAddress,
+            BattleTalkMemoryLayout layout,
+            out Snapshot snapshot) {
+            snapshot = null;
+            IntPtr uiModule;
+            IntPtr raptureAtkModule;
+            IntPtr unitManager;
+            IntPtr unitList;
+            IntPtr countAddress;
+            IntPtr entries;
+            ushort count;
+            if (!TryReadPointer(peek, uiModulePointerAddress, out uiModule)
+                || uiModule == IntPtr.Zero
+                || !TryAdd(uiModule, layout.RaptureAtkModuleOffset, out raptureAtkModule)
+                || !TryAdd(raptureAtkModule, layout.RaptureAtkUnitManagerOffset, out unitManager)
+                || !TryAdd(unitManager, layout.AllLoadedUnitsListOffset, out unitList)
+                || !TryAdd(unitList, layout.CountOffset, out countAddress)
+                || !TryReadUInt16(peek, countAddress, out count)
+                || count > layout.Capacity
+                || !TryAdd(unitList, layout.EntriesOffset, out entries)) {
+                return false;
+            }
+
+            IntPtr[] addons = new IntPtr[count];
+            int foundIndex = -1;
+            for (int index = 0; index < count; index++) {
+                IntPtr entry;
+                if (!TryAdd(entries, (long) index * layout.EntrySize, out entry)
+                    || !TryReadPointer(peek, entry, out addons[index])) {
+                    return false;
+                }
+
+                if (addons[index] != IntPtr.Zero && IsExpectedAddon(peek, addons[index], layout)) {
+                    if (foundIndex >= 0) return false;
+                    foundIndex = index;
+                }
+            }
+
+            if (foundIndex < 0) {
+                snapshot = new Snapshot(uiModule, unitList, count, addons);
+                return true;
+            }
+
+            IntPtr addon = addons[foundIndex];
+            IntPtr visibilityAddress;
+            IntPtr readinessAddress;
+            uint visibility;
+            byte readiness;
+            if (!TryAdd(addon, layout.VisibilityStateOffset, out visibilityAddress)
+                || !TryReadUInt32(peek, visibilityAddress, out visibility)
+                || !TryAdd(addon, layout.ReadinessOffset, out readinessAddress)
+                || !TryReadByte(peek, readinessAddress, out readiness)) {
+                return false;
+            }
+
+            bool isVisible = (visibility & layout.VisibilityMask) != 0;
+            bool isReady = (readiness & layout.ReadinessMask) != 0;
+            if (!isVisible || !isReady) {
+                snapshot = new Snapshot(
+                    uiModule,
+                    unitList,
+                    count,
+                    addons,
+                    foundIndex,
+                    visibility,
+                    readiness,
+                    isVisible,
+                    isReady);
+                return true;
+            }
+
+            IntPtr holder;
+            short numberCount;
+            short stringCount;
+            IntPtr numberArrays;
+            IntPtr stringArrays;
+            IntPtr numberData;
+            IntPtr stringData;
+            int numberSize;
+            int stringSize;
+            byte numberUpdate;
+            byte stringUpdate;
+            IntPtr numberValues;
+            IntPtr stringValues;
+            int visibleValue;
+            IntPtr namePointer;
+            IntPtr textPointer;
+            if (!TryAdd(raptureAtkModule, layout.AtkArrayDataHolderOffset, out holder)
+                || !TryReadInt16At(peek, holder, layout.NumberArrayCountOffset, out numberCount)
+                || numberCount <= layout.NumberArrayId
+                || !TryReadPointerAt(peek, holder, layout.NumberArraysOffset, out numberArrays)
+                || !TryReadPointerAt(peek, numberArrays, (long) layout.NumberArrayId * 8, out numberData)
+                || numberData == IntPtr.Zero
+                || !TryReadInt32At(peek, numberData, layout.ArraySizeOffset, out numberSize)
+                || numberSize <= layout.VisibleIndex
+                || numberSize > MaximumArraySize
+                || !TryReadByteAt(peek, numberData, layout.ArrayUpdateStateOffset, out numberUpdate)
+                || !TryReadPointerAt(peek, numberData, layout.NumberValuesOffset, out numberValues)
+                || !TryReadInt32At(peek, numberValues, (long) layout.VisibleIndex * 4, out visibleValue)
+                || visibleValue == 0
+                || !TryReadInt16At(peek, holder, layout.StringArrayCountOffset, out stringCount)
+                || stringCount <= layout.StringArrayId
+                || !TryReadPointerAt(peek, holder, layout.StringArraysOffset, out stringArrays)
+                || !TryReadPointerAt(peek, stringArrays, (long) layout.StringArrayId * 8, out stringData)
+                || stringData == IntPtr.Zero
+                || !TryReadInt32At(peek, stringData, layout.ArraySizeOffset, out stringSize)
+                || stringSize <= Math.Max(layout.NameIndex, layout.TextIndex)
+                || stringSize > MaximumArraySize
+                || !TryReadByteAt(peek, stringData, layout.ArrayUpdateStateOffset, out stringUpdate)
+                || !TryReadPointerAt(peek, stringData, layout.StringValuesOffset, out stringValues)
+                || !TryReadPointerAt(peek, stringValues, (long) layout.NameIndex * 8, out namePointer)
+                || namePointer == IntPtr.Zero
+                || !TryReadPointerAt(peek, stringValues, (long) layout.TextIndex * 8, out textPointer)
+                || textPointer == IntPtr.Zero) {
+                return false;
+            }
+
+            snapshot = new Snapshot(
+                uiModule,
+                unitList,
+                count,
+                addons,
+                foundIndex,
+                visibility,
+                readiness,
+                true,
+                true,
+                numberData,
+                numberSize,
+                numberUpdate,
+                numberValues,
+                visibleValue,
+                stringData,
+                stringSize,
+                stringUpdate,
+                stringValues,
+                namePointer,
+                textPointer);
+            return true;
+        }
+
+        private static bool TryReadNullTerminated(
+            MemoryPeek peek,
+            IntPtr pointer,
+            out byte[] value) {
+            List<byte> bytes = new List<byte>();
+            byte[] chunk = new byte[StringChunkSize];
+            for (int offset = 0; offset < MaximumStringBytes; offset += chunk.Length) {
+                IntPtr address;
+                int count = Math.Min(chunk.Length, MaximumStringBytes - offset);
+                if (!TryAdd(pointer, offset, out address)) {
+                    value = null;
+                    return false;
+                }
+
+                if (peek(address, chunk, count)) {
+                    for (int index = 0; index < count; index++) {
+                        if (chunk[index] == 0) {
+                            return TryFinishUtf8(bytes, out value);
+                        }
+
+                        bytes.Add(chunk[index]);
+                    }
+
+                    continue;
+                }
+
+                for (int index = 0; index < count; index++) {
+                    IntPtr byteAddress;
+                    byte single;
+                    if (!TryAdd(address, index, out byteAddress)
+                        || !TryReadByte(peek, byteAddress, out single)) {
+                        value = null;
+                        return false;
+                    }
+
+                    if (single == 0) return TryFinishUtf8(bytes, out value);
+                    bytes.Add(single);
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        private static bool TryFinishUtf8(List<byte> bytes, out byte[] value) {
+            value = bytes.ToArray();
+            try {
+                StrictUtf8.GetString(value);
+                return true;
+            }
+            catch (DecoderFallbackException) {
+                value = null;
+                return false;
+            }
+        }
+
+        private static bool IsExpectedAddon(
+            MemoryPeek peek,
+            IntPtr addon,
+            BattleTalkMemoryLayout layout) {
+            IntPtr nameAddress;
+            if (!TryAdd(addon, layout.AddonNameOffset, out nameAddress)) return false;
+            byte[] bytes = new byte[layout.AddonNameCapacity];
+            if (!peek(nameAddress, bytes, bytes.Length)) return false;
+            byte[] expected = Encoding.ASCII.GetBytes(layout.AddonName);
+            if (expected.Length >= bytes.Length || bytes[expected.Length] != 0) return false;
+            for (int index = 0; index < expected.Length; index++) {
+                if (bytes[index] != expected[index]) return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryReadPointerAt(
+            MemoryPeek peek,
+            IntPtr address,
+            long offset,
+            out IntPtr value) {
+            IntPtr target;
+            value = IntPtr.Zero;
+            return TryAdd(address, offset, out target) && TryReadPointer(peek, target, out value);
+        }
+
+        private static bool TryReadPointer(MemoryPeek peek, IntPtr address, out IntPtr value) {
+            byte[] bytes = new byte[8];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = IntPtr.Zero;
+                return false;
+            }
+
+            value = new IntPtr(BitConverter.ToInt64(bytes, 0));
+            return true;
+        }
+
+        private static bool TryReadInt16At(
+            MemoryPeek peek,
+            IntPtr address,
+            long offset,
+            out short value) {
+            IntPtr target;
+            byte[] bytes = new byte[2];
+            if (!TryAdd(address, offset, out target) || !peek(target, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToInt16(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadInt32At(
+            MemoryPeek peek,
+            IntPtr address,
+            long offset,
+            out int value) {
+            IntPtr target;
+            byte[] bytes = new byte[4];
+            if (!TryAdd(address, offset, out target) || !peek(target, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToInt32(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadUInt32(MemoryPeek peek, IntPtr address, out uint value) {
+            byte[] bytes = new byte[4];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToUInt32(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadUInt16(MemoryPeek peek, IntPtr address, out ushort value) {
+            byte[] bytes = new byte[2];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = BitConverter.ToUInt16(bytes, 0);
+            return true;
+        }
+
+        private static bool TryReadByteAt(
+            MemoryPeek peek,
+            IntPtr address,
+            long offset,
+            out byte value) {
+            IntPtr target;
+            value = 0;
+            return TryAdd(address, offset, out target) && TryReadByte(peek, target, out value);
+        }
+
+        private static bool TryReadByte(MemoryPeek peek, IntPtr address, out byte value) {
+            byte[] bytes = new byte[1];
+            if (!peek(address, bytes, bytes.Length)) {
+                value = 0;
+                return false;
+            }
+
+            value = bytes[0];
+            return true;
+        }
+
+        private static bool TryAdd(IntPtr address, long offset, out IntPtr result) {
+            try {
+                result = new IntPtr(checked(address.ToInt64() + offset));
+                return true;
+            }
+            catch (OverflowException) {
+                result = IntPtr.Zero;
+                return false;
+            }
+        }
+
+        private static bool BytesEqual(byte[] left, byte[] right) {
+            if (left.Length != right.Length) return false;
+            for (int index = 0; index < left.Length; index++) {
+                if (left[index] != right[index]) return false;
+            }
+
+            return true;
+        }
+
+        private sealed class Snapshot : IEquatable<Snapshot> {
+            internal Snapshot(
+                IntPtr uiModule,
+                IntPtr unitList,
+                ushort count,
+                IntPtr[] addons,
+                int foundIndex = -1,
+                uint visibility = 0,
+                byte readiness = 0,
+                bool isVisible = false,
+                bool isReady = false,
+                IntPtr numberData = default(IntPtr),
+                int numberSize = 0,
+                byte numberUpdate = 0,
+                IntPtr numberValues = default(IntPtr),
+                int visibleValue = 0,
+                IntPtr stringData = default(IntPtr),
+                int stringSize = 0,
+                byte stringUpdate = 0,
+                IntPtr stringValues = default(IntPtr),
+                IntPtr namePointer = default(IntPtr),
+                IntPtr textPointer = default(IntPtr)) {
+                this.UiModule = uiModule;
+                this.UnitList = unitList;
+                this.Count = count;
+                this.Addons = addons;
+                this.FoundIndex = foundIndex;
+                this.Visibility = visibility;
+                this.Readiness = readiness;
+                this.IsVisible = isVisible;
+                this.IsReady = isReady;
+                this.NumberData = numberData;
+                this.NumberSize = numberSize;
+                this.NumberUpdate = numberUpdate;
+                this.NumberValues = numberValues;
+                this.VisibleValue = visibleValue;
+                this.StringData = stringData;
+                this.StringSize = stringSize;
+                this.StringUpdate = stringUpdate;
+                this.StringValues = stringValues;
+                this.NamePointer = namePointer;
+                this.TextPointer = textPointer;
+            }
+
+            internal bool IsFound => this.FoundIndex >= 0;
+            internal bool IsVisible { get; }
+            internal bool IsReady { get; }
+            internal IntPtr NamePointer { get; }
+            internal IntPtr TextPointer { get; }
+            private IntPtr UiModule { get; }
+            private IntPtr UnitList { get; }
+            private ushort Count { get; }
+            private IntPtr[] Addons { get; }
+            private int FoundIndex { get; }
+            private uint Visibility { get; }
+            private byte Readiness { get; }
+            private IntPtr NumberData { get; }
+            private int NumberSize { get; }
+            private byte NumberUpdate { get; }
+            private IntPtr NumberValues { get; }
+            private int VisibleValue { get; }
+            private IntPtr StringData { get; }
+            private int StringSize { get; }
+            private byte StringUpdate { get; }
+            private IntPtr StringValues { get; }
+
+            public bool Equals(Snapshot other) {
+                if (other == null
+                    || this.UiModule != other.UiModule
+                    || this.UnitList != other.UnitList
+                    || this.Count != other.Count
+                    || this.FoundIndex != other.FoundIndex
+                    || this.Visibility != other.Visibility
+                    || this.Readiness != other.Readiness
+                    || this.IsVisible != other.IsVisible
+                    || this.IsReady != other.IsReady
+                    || this.NumberData != other.NumberData
+                    || this.NumberSize != other.NumberSize
+                    || this.NumberUpdate != other.NumberUpdate
+                    || this.NumberValues != other.NumberValues
+                    || this.VisibleValue != other.VisibleValue
+                    || this.StringData != other.StringData
+                    || this.StringSize != other.StringSize
+                    || this.StringUpdate != other.StringUpdate
+                    || this.StringValues != other.StringValues
+                    || this.NamePointer != other.NamePointer
+                    || this.TextPointer != other.TextPointer
+                    || this.Addons.Length != other.Addons.Length) {
+                    return false;
+                }
+
+                for (int index = 0; index < this.Addons.Length; index++) {
+                    if (this.Addons[index] != other.Addons[index]) return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/Sharlayan/Resources/HermesV2/embedded.json
+++ b/Sharlayan/Resources/HermesV2/embedded.json
@@ -8,7 +8,7 @@
     "fcsRepository": "https://github.com/aers/FFXIVClientStructs.git",
     "fcsCommit": "ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1",
     "generatorRepository": "https://github.com/sappho192/ffxiv-hermes.git",
-    "generatorCommit": "1a2ebec35e7f7f840e163e052ee02b7fce1bf1c6"
+    "generatorCommit": "617f2a25b350023e9e65fc5c9a5160042a2f91ce"
   },
   "platform": {
     "process": "ffxiv_dx11.exe",

--- a/Sharlayan/Resources/HermesV2/embedded.json
+++ b/Sharlayan/Resources/HermesV2/embedded.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 2,
   "compatibility": {
-    "minimumSharlayanVersion": "9.1.2",
+    "minimumSharlayanVersion": "9.2.0",
     "pointerResolverVersion": 1
   },
   "source": {
     "fcsRepository": "https://github.com/aers/FFXIVClientStructs.git",
-    "fcsCommit": "8ff04195c4e77ef0b85d15c6fd1c67785378f0fb",
+    "fcsCommit": "ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1",
     "generatorRepository": "https://github.com/sappho192/ffxiv-hermes.git",
-    "generatorCommit": "746414d55919677c79f6c3709f839ace556551aa"
+    "generatorCommit": "1a2ebec35e7f7f840e163e052ee02b7fce1bf1c6"
   },
   "platform": {
     "process": "ffxiv_dx11.exe",
@@ -75,12 +75,54 @@
       "addonName": "Talk",
       "textValueIndex": 0,
       "nameValueIndex": 1
+    },
+    "battleTalk": {
+      "root": "framework",
+      "semantics": "currentBattleTalk",
+      "uiModuleOffset": 11112,
+      "raptureAtkModuleOffset": 861808,
+      "raptureAtkUnitManagerOffset": 78880,
+      "allLoadedUnitsListOffset": 26880,
+      "atkUnitList": {
+        "entriesOffset": 8,
+        "countOffset": 2056,
+        "capacity": 256,
+        "entrySize": 8
+      },
+      "addon": {
+        "nameOffset": 8,
+        "nameCapacity": 32,
+        "visibilityStateOffset": 408,
+        "visibilityMask": 2097152,
+        "readinessOffset": 417,
+        "readinessMask": 1
+      },
+      "addonName": "_BattleTalk",
+      "atkArrayDataHolderOffset": 7080,
+      "arrayDataHolder": {
+        "numberArrayCountOffset": 0,
+        "numberArraysOffset": 24,
+        "stringArrayCountOffset": 2,
+        "stringArraysOffset": 48
+      },
+      "arrayData": {
+        "sizeOffset": 8,
+        "updateStateOffset": 31
+      },
+      "numberValuesOffset": 40,
+      "stringValuesOffset": 40,
+      "numberArrayId": 38,
+      "stringArrayId": 35,
+      "visibleIndex": 0,
+      "nameIndex": 0,
+      "textIndex": 1,
+      "sequenceSemantics": "visibilityOrContentGeneration"
     }
   },
   "validation": {
     "status": "live-verified",
     "gameVersion": "2026.06.18.0000.0000",
     "executableSha256": "4236e770e673150e85f8d10beab2fc4834c82f86aab8a555a9175439fc906a6d",
-    "verifierCommit": "3e27261f82851e1e88c413a25461e6ca0ad551e8"
+    "verifierCommit": "36ebee4a4926dd45607bf973c6205b8eec04b480"
   }
 }

--- a/Sharlayan/Resources/HermesV2ManifestParser.cs
+++ b/Sharlayan/Resources/HermesV2ManifestParser.cs
@@ -111,7 +111,7 @@ namespace Sharlayan.Resources {
             RequireBoolean(framework, "isPointer", "$.roots.framework.");
 
             JObject resources = RequireObject(root, "resources", "$.");
-            ValidateObject(resources, "$.resources", "chatLog", "talk", "currentTalk");
+            ValidateObject(resources, "$.resources", "chatLog", "talk", "currentTalk", "battleTalk");
             JObject chatLog = RequireObject(resources, "chatLog", "$.resources.");
             ValidateObject(chatLog, "$.resources.chatLog", "root", "uiModuleOffset", "raptureLogModuleOffset", "indexVectorOffset", "dataVectorOffset");
             RequireString(chatLog, "root", "$.resources.chatLog.");
@@ -197,6 +197,85 @@ namespace Sharlayan.Resources {
                 if (value.Type != JTokenType.Integer) {
                     throw new InvalidDataException("$.resources.currentTalk.atkValue.allowedStringTypes must contain integers.");
                 }
+            }
+
+            if (resources["battleTalk"] != null) {
+                JObject battleTalk = RequireObject(resources, "battleTalk", "$.resources.");
+                ValidateObject(
+                    battleTalk,
+                    "$.resources.battleTalk",
+                    "root",
+                    "semantics",
+                    "uiModuleOffset",
+                    "raptureAtkModuleOffset",
+                    "raptureAtkUnitManagerOffset",
+                    "allLoadedUnitsListOffset",
+                    "atkUnitList",
+                    "addon",
+                    "addonName",
+                    "atkArrayDataHolderOffset",
+                    "arrayDataHolder",
+                    "arrayData",
+                    "numberValuesOffset",
+                    "stringValuesOffset",
+                    "numberArrayId",
+                    "stringArrayId",
+                    "visibleIndex",
+                    "nameIndex",
+                    "textIndex",
+                    "sequenceSemantics");
+                RequireString(battleTalk, "root", "$.resources.battleTalk.");
+                RequireString(battleTalk, "semantics", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "uiModuleOffset", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "raptureAtkModuleOffset", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "raptureAtkUnitManagerOffset", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "allLoadedUnitsListOffset", "$.resources.battleTalk.");
+                RequireString(battleTalk, "addonName", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "atkArrayDataHolderOffset", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "numberValuesOffset", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "stringValuesOffset", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "numberArrayId", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "stringArrayId", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "visibleIndex", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "nameIndex", "$.resources.battleTalk.");
+                RequireInteger(battleTalk, "textIndex", "$.resources.battleTalk.");
+                RequireString(battleTalk, "sequenceSemantics", "$.resources.battleTalk.");
+
+                JObject battleList = RequireObject(battleTalk, "atkUnitList", "$.resources.battleTalk.");
+                ValidateObject(battleList, "$.resources.battleTalk.atkUnitList", "entriesOffset", "countOffset", "capacity", "entrySize");
+                RequireInteger(battleList, "entriesOffset", "$.resources.battleTalk.atkUnitList.");
+                RequireInteger(battleList, "countOffset", "$.resources.battleTalk.atkUnitList.");
+                RequireInteger(battleList, "capacity", "$.resources.battleTalk.atkUnitList.");
+                RequireInteger(battleList, "entrySize", "$.resources.battleTalk.atkUnitList.");
+
+                JObject battleAddon = RequireObject(battleTalk, "addon", "$.resources.battleTalk.");
+                ValidateObject(
+                    battleAddon,
+                    "$.resources.battleTalk.addon",
+                    "nameOffset",
+                    "nameCapacity",
+                    "visibilityStateOffset",
+                    "visibilityMask",
+                    "readinessOffset",
+                    "readinessMask");
+                RequireInteger(battleAddon, "nameOffset", "$.resources.battleTalk.addon.");
+                RequireInteger(battleAddon, "nameCapacity", "$.resources.battleTalk.addon.");
+                RequireInteger(battleAddon, "visibilityStateOffset", "$.resources.battleTalk.addon.");
+                RequireInteger(battleAddon, "visibilityMask", "$.resources.battleTalk.addon.");
+                RequireInteger(battleAddon, "readinessOffset", "$.resources.battleTalk.addon.");
+                RequireInteger(battleAddon, "readinessMask", "$.resources.battleTalk.addon.");
+
+                JObject holder = RequireObject(battleTalk, "arrayDataHolder", "$.resources.battleTalk.");
+                ValidateObject(holder, "$.resources.battleTalk.arrayDataHolder", "numberArrayCountOffset", "numberArraysOffset", "stringArrayCountOffset", "stringArraysOffset");
+                RequireInteger(holder, "numberArrayCountOffset", "$.resources.battleTalk.arrayDataHolder.");
+                RequireInteger(holder, "numberArraysOffset", "$.resources.battleTalk.arrayDataHolder.");
+                RequireInteger(holder, "stringArrayCountOffset", "$.resources.battleTalk.arrayDataHolder.");
+                RequireInteger(holder, "stringArraysOffset", "$.resources.battleTalk.arrayDataHolder.");
+
+                JObject arrayData = RequireObject(battleTalk, "arrayData", "$.resources.battleTalk.");
+                ValidateObject(arrayData, "$.resources.battleTalk.arrayData", "sizeOffset", "updateStateOffset");
+                RequireInteger(arrayData, "sizeOffset", "$.resources.battleTalk.arrayData.");
+                RequireInteger(arrayData, "updateStateOffset", "$.resources.battleTalk.arrayData.");
             }
 
             JObject validation = RequireObject(root, "validation", "$.");
@@ -398,6 +477,61 @@ namespace Sharlayan.Resources {
                 || currentTalk.TextValueIndex != 0
                 || currentTalk.NameValueIndex != 1) {
                 throw new InvalidDataException("CurrentTalk AtkValue semantics are invalid.");
+            }
+
+            HermesBattleTalkResource battleTalk = manifest.Resources.BattleTalk;
+            if (battleTalk != null) {
+                if (manifest.Compatibility.MinimumSharlayanVersion != "9.2.0"
+                    || battleTalk.Root != "framework"
+                    || battleTalk.Semantics != "currentBattleTalk"
+                    || battleTalk.AddonName != "_BattleTalk"
+                    || battleTalk.SequenceSemantics != "visibilityOrContentGeneration"
+                    || battleTalk.UiModuleOffset != currentTalk.UiModuleOffset
+                    || battleTalk.RaptureAtkModuleOffset != currentTalk.RaptureAtkModuleOffset
+                    || battleTalk.RaptureAtkUnitManagerOffset != currentTalk.RaptureAtkUnitManagerOffset
+                    || battleTalk.AllLoadedUnitsListOffset != currentTalk.AllLoadedUnitsListOffset
+                    || battleTalk.NumberArrayId != 38
+                    || battleTalk.StringArrayId != 35
+                    || battleTalk.VisibleIndex != 0
+                    || battleTalk.NameIndex != 0
+                    || battleTalk.TextIndex != 1) {
+                    throw new InvalidDataException("BattleTalk resource semantics are invalid.");
+                }
+
+                HermesAtkUnitListLayout battleList =
+                    battleTalk.AtkUnitList ?? throw new InvalidDataException("BattleTalk AtkUnitList layout is missing.");
+                HermesAddonVisibilityLayout battleAddon =
+                    battleTalk.Addon ?? throw new InvalidDataException("BattleTalk addon layout is missing.");
+                HermesAtkArrayDataHolderLayout holder =
+                    battleTalk.ArrayDataHolder ?? throw new InvalidDataException("BattleTalk array holder layout is missing.");
+                HermesAtkArrayDataLayout arrayData =
+                    battleTalk.ArrayData ?? throw new InvalidDataException("BattleTalk array data layout is missing.");
+                ValidateOffset(battleTalk.AtkArrayDataHolderOffset, nameof(battleTalk.AtkArrayDataHolderOffset));
+                ValidateOffset(holder.NumberArrayCountOffset, nameof(holder.NumberArrayCountOffset));
+                ValidateOffset(holder.NumberArraysOffset, nameof(holder.NumberArraysOffset));
+                ValidateOffset(holder.StringArrayCountOffset, nameof(holder.StringArrayCountOffset));
+                ValidateOffset(holder.StringArraysOffset, nameof(holder.StringArraysOffset));
+                ValidateOffset(arrayData.SizeOffset, nameof(arrayData.SizeOffset));
+                ValidateOffset(arrayData.UpdateStateOffset, nameof(arrayData.UpdateStateOffset));
+                ValidateOffset(battleTalk.NumberValuesOffset, nameof(battleTalk.NumberValuesOffset));
+                ValidateOffset(battleTalk.StringValuesOffset, nameof(battleTalk.StringValuesOffset));
+                if (battleList.EntriesOffset != unitList.EntriesOffset
+                    || battleList.CountOffset != unitList.CountOffset
+                    || battleList.Capacity != unitList.Capacity
+                    || battleList.EntrySize != unitList.EntrySize
+                    || battleAddon.NameOffset != addon.NameOffset
+                    || battleAddon.NameCapacity != addon.NameCapacity
+                    || battleAddon.VisibilityStateOffset != addon.VisibilityStateOffset
+                    || battleAddon.VisibilityMask != addon.VisibilityMask
+                    || battleAddon.ReadinessOffset != addon.ReadinessOffset
+                    || battleAddon.ReadinessMask != addon.ReadinessMask
+                    || holder.NumberArraysOffset % 8 != 0
+                    || holder.StringArraysOffset % 8 != 0
+                    || battleTalk.NumberValuesOffset % 8 != 0
+                    || battleTalk.StringValuesOffset % 8 != 0
+                    || arrayData.SizeOffset + sizeof(int) > arrayData.UpdateStateOffset) {
+                    throw new InvalidDataException("BattleTalk resource must share addon identity and use valid array headers.");
+                }
             }
 
             HermesValidation validation = manifest.Validation ?? throw new InvalidDataException("Validation metadata is missing.");

--- a/Sharlayan/Resources/HermesV2ResourceMapper.cs
+++ b/Sharlayan/Resources/HermesV2ResourceMapper.cs
@@ -12,17 +12,20 @@ namespace Sharlayan.Resources {
             Signature[] signatures,
             StructuresContainer structures,
             TalkMemoryLayout talkLayout,
-            CurrentTalkMemoryLayout currentTalkLayout) {
+            CurrentTalkMemoryLayout currentTalkLayout,
+            BattleTalkMemoryLayout battleTalkLayout) {
             this.Signatures = signatures;
             this.Structures = structures;
             this.TalkLayout = talkLayout;
             this.CurrentTalkLayout = currentTalkLayout;
+            this.BattleTalkLayout = battleTalkLayout;
         }
 
         internal Signature[] Signatures { get; }
         internal StructuresContainer Structures { get; }
         internal TalkMemoryLayout TalkLayout { get; }
         internal CurrentTalkMemoryLayout CurrentTalkLayout { get; }
+        internal BattleTalkMemoryLayout BattleTalkLayout { get; }
     }
 
     internal sealed class TalkMemoryLayout {
@@ -60,6 +63,37 @@ namespace Sharlayan.Resources {
         internal string AddonName { get; set; }
         internal int TextValueIndex { get; set; }
         internal int NameValueIndex { get; set; }
+    }
+
+    internal sealed class BattleTalkMemoryLayout {
+        internal int RaptureAtkModuleOffset { get; set; }
+        internal int RaptureAtkUnitManagerOffset { get; set; }
+        internal int AllLoadedUnitsListOffset { get; set; }
+        internal int EntriesOffset { get; set; }
+        internal int CountOffset { get; set; }
+        internal int Capacity { get; set; }
+        internal int EntrySize { get; set; }
+        internal int AddonNameOffset { get; set; }
+        internal int AddonNameCapacity { get; set; }
+        internal int VisibilityStateOffset { get; set; }
+        internal uint VisibilityMask { get; set; }
+        internal int ReadinessOffset { get; set; }
+        internal uint ReadinessMask { get; set; }
+        internal string AddonName { get; set; }
+        internal int AtkArrayDataHolderOffset { get; set; }
+        internal int NumberArrayCountOffset { get; set; }
+        internal int NumberArraysOffset { get; set; }
+        internal int StringArrayCountOffset { get; set; }
+        internal int StringArraysOffset { get; set; }
+        internal int ArraySizeOffset { get; set; }
+        internal int ArrayUpdateStateOffset { get; set; }
+        internal int NumberValuesOffset { get; set; }
+        internal int StringValuesOffset { get; set; }
+        internal int NumberArrayId { get; set; }
+        internal int StringArrayId { get; set; }
+        internal int VisibleIndex { get; set; }
+        internal int NameIndex { get; set; }
+        internal int TextIndex { get; set; }
     }
 
     internal static class HermesV2ResourceMapper {
@@ -119,7 +153,47 @@ namespace Sharlayan.Resources {
                 TextValueIndex = currentTalk.TextValueIndex,
                 NameValueIndex = currentTalk.NameValueIndex,
             };
-            return new HermesMappedResources(signatures, structures, layout, currentLayout);
+            BattleTalkMemoryLayout battleLayout = null;
+            HermesBattleTalkResource battle = manifest.Resources.BattleTalk;
+            if (battle != null) {
+                battleLayout = new BattleTalkMemoryLayout {
+                    RaptureAtkModuleOffset = battle.RaptureAtkModuleOffset,
+                    RaptureAtkUnitManagerOffset = battle.RaptureAtkUnitManagerOffset,
+                    AllLoadedUnitsListOffset = battle.AllLoadedUnitsListOffset,
+                    EntriesOffset = battle.AtkUnitList.EntriesOffset,
+                    CountOffset = battle.AtkUnitList.CountOffset,
+                    Capacity = battle.AtkUnitList.Capacity,
+                    EntrySize = battle.AtkUnitList.EntrySize,
+                    AddonNameOffset = battle.Addon.NameOffset,
+                    AddonNameCapacity = battle.Addon.NameCapacity,
+                    VisibilityStateOffset = battle.Addon.VisibilityStateOffset,
+                    VisibilityMask = battle.Addon.VisibilityMask,
+                    ReadinessOffset = battle.Addon.ReadinessOffset,
+                    ReadinessMask = battle.Addon.ReadinessMask,
+                    AddonName = battle.AddonName,
+                    AtkArrayDataHolderOffset = battle.AtkArrayDataHolderOffset,
+                    NumberArrayCountOffset = battle.ArrayDataHolder.NumberArrayCountOffset,
+                    NumberArraysOffset = battle.ArrayDataHolder.NumberArraysOffset,
+                    StringArrayCountOffset = battle.ArrayDataHolder.StringArrayCountOffset,
+                    StringArraysOffset = battle.ArrayDataHolder.StringArraysOffset,
+                    ArraySizeOffset = battle.ArrayData.SizeOffset,
+                    ArrayUpdateStateOffset = battle.ArrayData.UpdateStateOffset,
+                    NumberValuesOffset = battle.NumberValuesOffset,
+                    StringValuesOffset = battle.StringValuesOffset,
+                    NumberArrayId = battle.NumberArrayId,
+                    StringArrayId = battle.StringArrayId,
+                    VisibleIndex = battle.VisibleIndex,
+                    NameIndex = battle.NameIndex,
+                    TextIndex = battle.TextIndex,
+                };
+            }
+
+            return new HermesMappedResources(
+                signatures,
+                structures,
+                layout,
+                currentLayout,
+                battleLayout);
         }
 
         private static Signature CreateSignature(string key, string pattern, long rewindOffset, int uiModuleOffset, int resourceOffset) {

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -15,12 +15,12 @@
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<PackageValidationBaselineVersion>8.0.1</PackageValidationBaselineVersion>
-		<Version>9.1.4</Version>
+		<Version>9.2.0</Version>
 		<Company>SyndicatedLife</Company>
 		<Product>Sharlayan.Lite</Product>
-		<Description>Lightweight FFXIV memory scanning with ChatLog and standard NPC Talk reading.</Description>
+		<Description>Lightweight FFXIV memory scanning with ChatLog and dialogue UI reading.</Description>
 		<Copyright>Copyright © 2007 - 2024 Ryan Wilson</Copyright>
-		<FileVersion>9.1.4.0</FileVersion>
+		<FileVersion>9.2.0.0</FileVersion>
 		<AssemblyVersion>8.0.0.0</AssemblyVersion>
 		<RootNamespace>Sharlayan</RootNamespace>
 		<PackageId>Sharlayan.Lite</PackageId>

--- a/tools/Sharlayan.LiveSmoke/Program.cs
+++ b/tools/Sharlayan.LiveSmoke/Program.cs
@@ -5,6 +5,10 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+using Newtonsoft.Json;
 
 using Sharlayan;
 using Sharlayan.Models;
@@ -124,6 +128,27 @@ internal static class Program {
                         handler.Reader.CanGetTalk(),
                         handler.Reader.GetTalk(),
                         options.PrintTalk);
+                }
+
+                if (options.RequireBattleTalk) {
+                    ValidateBattleTalk(
+                        handler.Reader.CanGetBattleTalk(),
+                        handler.Reader.GetBattleTalk(),
+                        options.PrintTalk);
+                }
+
+                if (options.BattleTalkSequenceSeconds > 0) {
+                    await RunBattleTalkSequenceProbe(
+                        handler,
+                        process,
+                        exceptions,
+                        options,
+                        firstPoll.PreviousArrayIndex,
+                        firstPoll.PreviousOffset);
+                }
+
+                if (options.BattleTalkProbeLayoutPath != null) {
+                    await RunBattleTalkContractProbe(handler, process, exceptions, resourceInfo, options);
                 }
 
                 if (options.ConcurrentReaders > 1) {
@@ -386,10 +411,239 @@ internal static class Program {
         }
     }
 
+    private static void ValidateBattleTalk(
+        bool canRead,
+        BattleTalkResult battleTalk,
+        bool printTalk) {
+        if (!canRead) {
+            throw new InvalidOperationException("BattleTalk resource was not resolved.");
+        }
+
+        if (!battleTalk.IsAvailable
+            || !battleTalk.IsVisible
+            || string.IsNullOrEmpty(battleTalk.Text)
+            || battleTalk.Sequence < 1) {
+            throw new InvalidOperationException(
+                "No visible BattleTalk value is available. Open a BattleTalk and retry.");
+        }
+
+        Console.WriteLine(
+            $"BattleTalk: available, visible, sequence={battleTalk.Sequence}, "
+            + $"nameUtf16Length={battleTalk.Name.Length}, textUtf16Length={battleTalk.Text.Length}");
+        if (printTalk) {
+            Console.WriteLine($"BattleTalk name: {battleTalk.Name}");
+            Console.WriteLine($"BattleTalk text: {battleTalk.Text}");
+        }
+    }
+
+    private static async Task RunBattleTalkSequenceProbe(
+        MemoryHandler handler,
+        Process process,
+        ConcurrentQueue<Exception> exceptions,
+        Options options,
+        int chatArrayIndex,
+        int chatOffset) {
+        if (!handler.Reader.CanGetBattleTalk()) {
+            throw new InvalidOperationException("BattleTalk resource was not resolved.");
+        }
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        TimeSpan duration = TimeSpan.FromSeconds(options.BattleTalkSequenceSeconds);
+        TimeSpan interval = TimeSpan.FromMilliseconds(options.BattleTalkSequenceIntervalMilliseconds);
+        string? previous = null;
+        long maximumSequence = 0;
+        int changes = 0;
+        int relevantChatEntries = 0;
+        int correlatedChatEntries = 0;
+        string visibleText = string.Empty;
+        Console.WriteLine(
+            $"BattleTalk sequence probe: interval={options.BattleTalkSequenceIntervalMilliseconds}ms, "
+            + $"duration={options.BattleTalkSequenceSeconds}s");
+        while (stopwatch.Elapsed < duration) {
+            if (process.HasExited) {
+                throw new InvalidOperationException("FFXIV exited during the BattleTalk sequence probe.");
+            }
+
+            BattleTalkResult result = handler.Reader.GetBattleTalk();
+            if (result.Sequence < maximumSequence) {
+                throw new InvalidOperationException("BattleTalk Sequence moved backwards.");
+            }
+
+            maximumSequence = Math.Max(maximumSequence, result.Sequence);
+            if (result.IsAvailable) {
+                visibleText = result.IsVisible ? result.Text : string.Empty;
+            }
+            string fingerprint =
+                $"{result.IsAvailable}:{result.IsVisible}:{result.Sequence}:{HashText(result.Name)}:{HashText(result.Text)}";
+            if (!string.Equals(previous, fingerprint, StringComparison.Ordinal)) {
+                previous = fingerprint;
+                changes++;
+                Console.WriteLine(
+                    $"BT-API {stopwatch.Elapsed.TotalSeconds,7:F3}s "
+                    + $"available={result.IsAvailable} visible={result.IsVisible} sequence={result.Sequence} "
+                    + $"nameLength={result.Name.Length} nameHash={HashText(result.Name)} "
+                    + $"textLength={result.Text.Length} textHash={HashText(result.Text)}");
+            }
+
+            ChatLogResult chat = handler.Reader.GetChatLog(chatArrayIndex, chatOffset);
+            chatArrayIndex = chat.PreviousArrayIndex;
+            chatOffset = chat.PreviousOffset;
+            while (chat.ChatLogItems.TryDequeue(out var item)) {
+                if (!int.TryParse(
+                        item.Code,
+                        NumberStyles.HexNumber,
+                        CultureInfo.InvariantCulture,
+                        out int code)
+                    || (code != 0x3D && code != 0x2AB9)) {
+                    continue;
+                }
+
+                relevantChatEntries++;
+                string message = item.Message ?? string.Empty;
+                bool correlated = !string.IsNullOrEmpty(visibleText)
+                                  && !string.IsNullOrEmpty(message)
+                                  && (string.Equals(message, visibleText, StringComparison.Ordinal)
+                                      || message.Contains(visibleText, StringComparison.Ordinal)
+                                      || visibleText.Contains(message, StringComparison.Ordinal));
+                if (correlated) correlatedChatEntries++;
+                Console.WriteLine(
+                    $"BT-CHAT code={item.Code} messageLength={message.Length} "
+                    + $"messageHash={HashText(message)} correlated={correlated}");
+            }
+
+            ThrowIfObserved(exceptions);
+            TimeSpan remaining = duration - stopwatch.Elapsed;
+            if (remaining > TimeSpan.Zero) {
+                await Task.Delay(remaining < interval ? remaining : interval);
+            }
+        }
+
+        Console.WriteLine(
+            $"BattleTalk sequence probe complete: changes={changes}, maximumSequence={maximumSequence}, "
+            + $"relevantChatEntries={relevantChatEntries}, correlatedChatEntries={correlatedChatEntries}");
+    }
+
+    private static string HashText(string value) {
+        if (string.IsNullOrEmpty(value)) return "-";
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(hash, 0, 6).ToLowerInvariant();
+    }
+
+    private static async Task RunBattleTalkContractProbe(
+        MemoryHandler handler,
+        Process process,
+        ConcurrentQueue<Exception> exceptions,
+        ResourceInfo resourceInfo,
+        Options options) {
+        string json = File.ReadAllText(options.BattleTalkProbeLayoutPath!);
+        BattleTalkProbeLayout layout = JsonConvert.DeserializeObject<BattleTalkProbeLayout>(json)
+            ?? throw new InvalidDataException("BattleTalk probe layout could not be deserialized.");
+        if (!handler.Scanner.Locations.TryGetValue(
+                Signatures.CURRENT_TALK_UI_MODULE_POINTER_KEY,
+                out MemoryLocation? location)) {
+            throw new InvalidOperationException("UI module pointer location was not resolved.");
+        }
+
+        if (!string.Equals(resourceInfo.FcsCommit, layout.FcsCommit, StringComparison.OrdinalIgnoreCase)) {
+            Console.WriteLine(
+                $"BattleTalk probe warning: runtime manifest FCS={resourceInfo.FcsCommit}, probe layout FCS={layout.FcsCommit}");
+        }
+
+        IntPtr uiModulePointerAddress = location.GetAddress();
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        TimeSpan duration = TimeSpan.FromSeconds(options.BattleTalkProbeSeconds);
+        TimeSpan interval = TimeSpan.FromMilliseconds(options.BattleTalkProbeIntervalMilliseconds);
+        string? previousFingerprint = null;
+        int observations = 0;
+        int changes = 0;
+        Console.WriteLine(
+            $"BattleTalk probe: layout={options.BattleTalkProbeLayoutPath}, interval={options.BattleTalkProbeIntervalMilliseconds}ms, duration={options.BattleTalkProbeSeconds}s");
+        while (stopwatch.Elapsed < duration) {
+            if (process.HasExited) {
+                throw new InvalidOperationException("FFXIV exited during the BattleTalk contract probe.");
+            }
+
+            BattleTalkProbeObservation observation =
+                BattleTalkContractProbe.Read(handler.Peek, uiModulePointerAddress, layout);
+            observations++;
+            if (!string.Equals(previousFingerprint, observation.Fingerprint, StringComparison.Ordinal)) {
+                changes++;
+                previousFingerprint = observation.Fingerprint;
+                PrintBattleTalkObservation(stopwatch.Elapsed, observation);
+            }
+
+            ThrowIfObserved(exceptions);
+            TimeSpan remaining = duration - stopwatch.Elapsed;
+            if (remaining > TimeSpan.Zero) {
+                await Task.Delay(remaining < interval ? remaining : interval);
+            }
+        }
+
+        Console.WriteLine($"BattleTalk probe complete: observations={observations}, changes={changes}");
+    }
+
+    private static void PrintBattleTalkObservation(TimeSpan elapsed, BattleTalkProbeObservation observation) {
+        BattleTalkProbeAddonObservation addon = observation.Addon;
+        Console.WriteLine(
+            $"BT {elapsed.TotalSeconds,7:F3}s fp={ShortHash(observation.Fingerprint)} "
+            + $"addon=r{Bool(addon.IsReadable)}f{Bool(addon.IsFound)}v{Bool(addon.IsVisible)}y{Bool(addon.IsReady)}"
+            + $"/count={addon.AtkValueCount}/strings={FormatStrings(addon.Strings)} "
+            + $"number=r{Bool(observation.NumberArray.IsReadable)}/u{observation.NumberArray.UpdateState}"
+            + $"/values=[{string.Join(",", observation.NumberArray.Values)}] "
+            + $"string=r{Bool(observation.StringArray.IsReadable)}/u{observation.StringArray.UpdateState}"
+            + $"/values={FormatStrings(observation.StringArray.Values)} "
+            + $"queue={FormatQueue(observation.QueueSlots)}");
+    }
+
+    private static string FormatStrings(IReadOnlyDictionary<int, BattleTalkProbeString> values) {
+        return "[" + string.Join(
+            ",",
+            values.Select(pair =>
+                $"{pair.Key}:p{pair.Value.Pointer.ToInt64():X}:l{pair.Value.Utf8Length}:h{ShortHash(pair.Value.Hash)}"))
+            + "]";
+    }
+
+    private static string FormatQueue(IReadOnlyList<BattleTalkProbeQueueSlot> slots) {
+        return "[" + string.Join(
+            ",",
+            slots.Where(slot =>
+                    !slot.IsReadable
+                    || slot.IsPending
+                    || (slot.Name != null && slot.Name.Utf8Length > 0)
+                    || (slot.Text != null && slot.Text.Utf8Length > 0))
+                .Select(slot =>
+                    $"{slot.Index}:r{Bool(slot.IsReadable)}p{Bool(slot.IsPending)}/s{slot.Style}"
+                    + $"/n={FormatString(slot.Name)}/t={FormatString(slot.Text)}"
+                    + $"/i{slot.Image}/a{slot.Sound}/e{slot.EntityId}"))
+            + "]";
+    }
+
+    private static string FormatString(BattleTalkProbeString? value) {
+        return value == null
+            ? "-"
+            : $"p{value.Pointer.ToInt64():X}:l{value.Utf8Length}:h{ShortHash(value.Hash)}";
+    }
+
+    private static string ShortHash(string value) {
+        return string.IsNullOrEmpty(value) ? "-" : value.Substring(0, Math.Min(12, value.Length));
+    }
+
+    private static int Bool(bool value) => value ? 1 : 0;
+
     private sealed class Options {
         public int InitializationTimeoutSeconds { get; private set; } = 30;
 
         public bool AttachOnly { get; private set; }
+
+        public int BattleTalkProbeIntervalMilliseconds { get; private set; } = 100;
+
+        public string? BattleTalkProbeLayoutPath { get; private set; }
+
+        public int BattleTalkProbeSeconds { get; private set; } = 120;
+
+        public int BattleTalkSequenceIntervalMilliseconds { get; private set; } = 100;
+
+        public int BattleTalkSequenceSeconds { get; private set; }
 
         public Uri? HermesV2LatestUri { get; private set; }
 
@@ -421,6 +675,8 @@ internal static class Program {
 
         public bool RequireCurrentTalk { get; private set; }
 
+        public bool RequireBattleTalk { get; private set; }
+
         public bool RequireLastTalk { get; private set; }
 
         public bool RequireTalk { get; private set; }
@@ -431,6 +687,21 @@ internal static class Program {
                 switch (args[index]) {
                     case "--attach-only":
                         options.AttachOnly = true;
+                        break;
+                    case "--battle-talk-probe-interval":
+                        options.BattleTalkProbeIntervalMilliseconds = ReadPositiveInt(args, ref index);
+                        break;
+                    case "--battle-talk-probe-layout":
+                        options.BattleTalkProbeLayoutPath = Path.GetFullPath(ReadString(args, ref index));
+                        break;
+                    case "--battle-talk-probe-seconds":
+                        options.BattleTalkProbeSeconds = ReadPositiveInt(args, ref index);
+                        break;
+                    case "--battle-talk-sequence-interval":
+                        options.BattleTalkSequenceIntervalMilliseconds = ReadPositiveInt(args, ref index);
+                        break;
+                    case "--battle-talk-sequence-seconds":
+                        options.BattleTalkSequenceSeconds = ReadPositiveInt(args, ref index);
                         break;
                     case "--initialization-timeout":
                         options.InitializationTimeoutSeconds = ReadPositiveInt(args, ref index);
@@ -480,6 +751,9 @@ internal static class Program {
                     case "--require-current-talk":
                         options.RequireCurrentTalk = true;
                         break;
+                    case "--require-battle-talk":
+                        options.RequireBattleTalk = true;
+                        break;
                     case "--require-last-talk":
                         options.RequireLastTalk = true;
                         break;
@@ -501,6 +775,18 @@ internal static class Program {
 
             if (options.ConcurrentCalls > 10000) {
                 throw new ArgumentOutOfRangeException(nameof(args), "--concurrent-calls cannot exceed 10000.");
+            }
+
+            if (options.BattleTalkProbeIntervalMilliseconds > 200) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(args),
+                    "--battle-talk-probe-interval cannot exceed 200 ms.");
+            }
+
+            if (options.BattleTalkSequenceIntervalMilliseconds > 200) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(args),
+                    "--battle-talk-sequence-interval cannot exceed 200 ms.");
             }
 
             return options;

--- a/tools/Sharlayan.PackageContractConsumer/Program.cs
+++ b/tools/Sharlayan.PackageContractConsumer/Program.cs
@@ -25,18 +25,28 @@ internal static class Program {
         AssertPublicMethod(nameof(Reader.GetTalk), typeof(TalkResult));
         AssertPublicMethod(nameof(Reader.GetCurrentTalk), typeof(TalkResult));
         AssertPublicMethod(nameof(Reader.GetLastTalk), typeof(TalkResult));
-        AssertPublicProperty(nameof(TalkResult.Source), typeof(TalkSource));
-        AssertPublicProperty(nameof(TalkResult.IsVisible), typeof(bool));
-        AssertPublicProperty(nameof(TalkResult.IsAvailable), typeof(bool));
-        AssertPublicProperty(nameof(TalkResult.Name), typeof(string));
-        AssertPublicProperty(nameof(TalkResult.Text), typeof(string));
+        AssertPublicMethod(nameof(Reader.CanGetBattleTalk), typeof(bool));
+        AssertPublicMethod(nameof(Reader.GetBattleTalk), typeof(BattleTalkResult));
+        AssertPublicProperty<TalkResult>(nameof(TalkResult.Source), typeof(TalkSource));
+        AssertPublicProperty<TalkResult>(nameof(TalkResult.IsVisible), typeof(bool));
+        AssertPublicProperty<TalkResult>(nameof(TalkResult.IsAvailable), typeof(bool));
+        AssertPublicProperty<TalkResult>(nameof(TalkResult.Name), typeof(string));
+        AssertPublicProperty<TalkResult>(nameof(TalkResult.Text), typeof(string));
+        AssertPublicProperty<BattleTalkResult>(nameof(BattleTalkResult.IsAvailable), typeof(bool));
+        AssertPublicProperty<BattleTalkResult>(nameof(BattleTalkResult.IsVisible), typeof(bool));
+        AssertPublicProperty<BattleTalkResult>(nameof(BattleTalkResult.Name), typeof(string));
+        AssertPublicProperty<BattleTalkResult>(nameof(BattleTalkResult.Text), typeof(string));
+        AssertPublicProperty<BattleTalkResult>(nameof(BattleTalkResult.Sequence), typeof(long));
 
         Console.WriteLine(
-            $"PACKAGE CONTRACT PASS: Sharlayan.Lite {actualVersion}, current-first Talk API and result properties available.");
+            $"PACKAGE CONTRACT PASS: Sharlayan.Lite {actualVersion}, Talk and BattleTalk APIs available.");
         return 0;
     }
 
-    private static void CompilePublicContract(Reader reader, TalkResult result) {
+    private static void CompilePublicContract(
+        Reader reader,
+        TalkResult result,
+        BattleTalkResult battleTalk) {
         _ = reader.CanGetTalk();
         _ = reader.GetTalk();
         _ = reader.GetCurrentTalk();
@@ -46,6 +56,13 @@ internal static class Program {
         _ = result.IsAvailable;
         _ = result.Name;
         _ = result.Text;
+        _ = reader.CanGetBattleTalk();
+        _ = reader.GetBattleTalk();
+        _ = battleTalk.IsAvailable;
+        _ = battleTalk.IsVisible;
+        _ = battleTalk.Name;
+        _ = battleTalk.Text;
+        _ = battleTalk.Sequence;
     }
 
     private static void AssertPublicMethod(string name, Type returnType) {
@@ -56,11 +73,11 @@ internal static class Program {
         }
     }
 
-    private static void AssertPublicProperty(string name, Type propertyType) {
-        PropertyInfo property = typeof(TalkResult).GetProperty(name, BindingFlags.Instance | BindingFlags.Public)
-                                ?? throw new MissingMemberException(typeof(TalkResult).FullName, name);
+    private static void AssertPublicProperty<TResult>(string name, Type propertyType) {
+        PropertyInfo property = typeof(TResult).GetProperty(name, BindingFlags.Instance | BindingFlags.Public)
+                                ?? throw new MissingMemberException(typeof(TResult).FullName, name);
         if (property.PropertyType != propertyType || property.GetMethod?.IsPublic != true) {
-            throw new InvalidOperationException($"TalkResult.{name} has an unexpected public signature.");
+            throw new InvalidOperationException($"{typeof(TResult).Name}.{name} has an unexpected public signature.");
         }
     }
 }

--- a/tools/Sharlayan.PackageContractConsumer/Sharlayan.PackageContractConsumer.csproj
+++ b/tools/Sharlayan.PackageContractConsumer/Sharlayan.PackageContractConsumer.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <SharlayanPackageVersion Condition="'$(SharlayanPackageVersion)' == ''">9.1.4</SharlayanPackageVersion>
+    <SharlayanPackageVersion Condition="'$(SharlayanPackageVersion)' == ''">9.2.0</SharlayanPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Verify-Package.ps1
+++ b/tools/Verify-Package.ps1
@@ -11,7 +11,7 @@ param(
 
     [string] $ExpectedRepositoryUrl = 'https://github.com/sappho192/Sharlayan.Lite',
 
-    [long] $MaximumBytes = 650000
+    [long] $MaximumBytes = 800000
 )
 
 $ErrorActionPreference = 'Stop'
@@ -82,6 +82,7 @@ function Assert-PublicPackageContract {
     $readerType = $assembly.GetType('Sharlayan.Reader', $true)
     $talkResultType = $assembly.GetType('Sharlayan.Models.ReadResults.TalkResult', $true)
     $talkSourceType = $assembly.GetType('Sharlayan.Models.ReadResults.TalkSource', $true)
+    $battleTalkResultType = $assembly.GetType('Sharlayan.Models.ReadResults.BattleTalkResult', $true)
     $informationalVersion = @(
         $assembly.GetCustomAttributes([System.Reflection.AssemblyInformationalVersionAttribute], $false)
     )[0].InformationalVersion
@@ -100,6 +101,8 @@ function Assert-PublicPackageContract {
         GetTalk = $talkResultType
         GetCurrentTalk = $talkResultType
         GetLastTalk = $talkResultType
+        CanGetBattleTalk = [bool]
+        GetBattleTalk = $battleTalkResultType
     }
     foreach ($contract in $methodContracts.GetEnumerator()) {
         $method = $readerType.GetMethod(
@@ -128,6 +131,33 @@ function Assert-PublicPackageContract {
             -not $property.GetMethod.IsPublic -or
             $property.PropertyType -ne $contract.Value) {
             throw "Package public contract is missing TalkResult.$($contract.Key)."
+        }
+    }
+
+    $resultContracts = @(
+        [pscustomobject]@{
+            Type = $battleTalkResultType
+            Name = 'BattleTalkResult'
+            Properties = @{
+                IsAvailable = [bool]
+                IsVisible = [bool]
+                Name = [string]
+                Text = [string]
+                Sequence = [long]
+            }
+        }
+    )
+    foreach ($resultContract in $resultContracts) {
+        foreach ($contract in $resultContract.Properties.GetEnumerator()) {
+            $property = $resultContract.Type.GetProperty(
+                $contract.Key,
+                [System.Reflection.BindingFlags]::Instance -bor [System.Reflection.BindingFlags]::Public)
+            if ($null -eq $property -or
+                $null -eq $property.GetMethod -or
+                -not $property.GetMethod.IsPublic -or
+                $property.PropertyType -ne $contract.Value) {
+                throw "Package public contract is missing $($resultContract.Name).$($contract.Key)."
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- add `CanGetBattleTalk()` and `GetBattleTalk()` public APIs
- read the canonical BattleTalk UI arrays behind stable addon visibility snapshots
- expose per-handler `Sequence` generations
- add privacy-preserving live probes and package-contract validation
- bump Sharlayan.Lite to 9.2.0

TalkSubtitle is intentionally not included in this release.

## Validation

- all target frameworks build with zero warnings/errors
- Sharlayan tests: 75 passed on net8.0 and net10.0
- package and clean consumer verification passed
- local package size: 718,975 bytes combined
- committed Hermes candidate live smoke passed, including Sequence 1 to 2 during a visible-to-visible replacement