### PR TITLE
Dispose BattleTalk probe hashers

### DIFF
--- a/Sharlayan/Resources/BattleTalkContractProbe.cs
+++ b/Sharlayan/Resources/BattleTalkContractProbe.cs
@@ -329,8 +329,11 @@ namespace Sharlayan.Resources {
             value = BattleTalkProbeString.Empty;
             try {
                 StrictUtf8.GetString(bytes, 0, count);
-                string hash = ToLowerHex(SHA256.Create().ComputeHash(bytes, 0, count))
-                    .Substring(0, 16);
+                string hash;
+                using (SHA256 sha256 = SHA256.Create()) {
+                    hash = ToLowerHex(sha256.ComputeHash(bytes, 0, count)).Substring(0, 16);
+                }
+
                 value = new BattleTalkProbeString(pointer, count, hash);
                 return true;
             }
@@ -379,7 +382,9 @@ namespace Sharlayan.Resources {
             }
 
             byte[] bytes = Encoding.UTF8.GetBytes(builder.ToString());
-            return ToLowerHex(SHA256.Create().ComputeHash(bytes));
+            using (SHA256 sha256 = SHA256.Create()) {
+                return ToLowerHex(sha256.ComputeHash(bytes));
+            }
         }
 
         private static string ToLowerHex(byte[] bytes) {


### PR DESCRIPTION
## Summary

- dispose the two `SHA256` instances created by the BattleTalk contract probe
- preserve the existing hash output and multi-target compatibility

## Root cause

The diagnostic probe created disposable hashers on every observation and successful string read without disposing them.

## Validation

- `dotnet test Sharlayan.Tests/Sharlayan.Tests.csproj --configuration Release --no-restore` (75 passed on net8.0; 75 passed on net10.0)
- `dotnet build Sharlayan/Sharlayan.csproj --configuration Release --no-restore` (net462, net48, net6.0, net7.0, net8.0, net10.0; 0 warnings/errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sappho192/sharlayan.lite/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->