### PR TITLE
Accept generated Hermes manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Verify package
         shell: pwsh
-        run: ./tools/Verify-Package.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.2.0 -ExpectedRepositoryCommit $env:GITHUB_SHA
+        run: ./tools/Verify-Package.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.2.1 -ExpectedRepositoryCommit $env:GITHUB_SHA
 
       - name: Verify clean package consumer
         shell: pwsh
-        run: ./tools/Verify-PackageConsumer.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.2.0 -ExpectedRepositoryCommit $env:GITHUB_SHA
+        run: ./tools/Verify-PackageConsumer.ps1 -PackageDirectory artifacts/packages -ExpectedPackageVersion 9.2.1 -ExpectedRepositoryCommit $env:GITHUB_SHA
 
       - name: Upload package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,24 +13,27 @@ This file applies to the whole Sharlayan.Lite repository.
 
 ## Supported package baseline
 
-- Current source package version: `9.1.4`.
-- Latest published package version: `9.1.4`.
+- Current source package version: `9.2.1`.
+- Latest published package version: `9.2.0`.
 - Target frameworks: `net462;net48;net6.0;net7.0;net8.0;net10.0`.
-- File version: `9.1.4.0`.
+- File version: `9.2.1.0`.
 - Assembly version remains `8.0.0.0` for binary compatibility.
 - Current embedded Hermes revision:
   `sha256:419248bf2ef93aa64e72723ea9e97d5503163178dab63e90a8155b359ebcf96d`.
 
 ## Hermes v2 invariants
 
-- Resource priority is remote → verified cache → embedded.
-- Validate schema, compatibility, revision hash, validation metadata, and every required layout
+- Resource priority is remote → valid cache → embedded.
+- Validate schema, compatibility, revision hash, publication status, and every required layout
   before applying a manifest.
 - CHATLOG, LastTalk, and currentTalk must come from the same manifest revision and be applied
   atomically. Never mix remote signatures with embedded structures.
 - Freeze the selected revision for a handler lifetime. Do not hot-swap part of a running handler.
-- Embedded production bytes must match the live-verified Hermes immutable object exactly. Preserve
+- Embedded production bytes must match a Hermes immutable object exactly. Preserve
   LF/no-BOM rules and never embed a candidate.
+- Remote and cache manifests may be `generated` or `live-verified`. A generated manifest is accepted
+  only when its compatibility floor includes Sharlayan.Lite 9.2.1 or newer and it contains no live
+  verification metadata.
 - Remote failure must fall back to cache/embedded rather than fail handler construction.
 
 ## Talk semantics

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Supported targets: .NET Framework 4.6.2 and 4.8, plus .NET 6, 7, 8, and 10.
 
 # How do I use it and what comes back?
 
-- .NET CLI: `dotnet add package Sharlayan.Lite --version 9.2.0`
-- Nuget Package Manager: `Install-Package Sharlayan.Lite -Version 9.2.0`
-- PackageReference: `<PackageReference Include="Sharlayan.Lite" Version="9.2.0" />`
+- .NET CLI: `dotnet add package Sharlayan.Lite --version 9.2.1`
+- Nuget Package Manager: `Install-Package Sharlayan.Lite -Version 9.2.1`
+- PackageReference: `<PackageReference Include="Sharlayan.Lite" Version="9.2.1" />`
 
 That's the basic of it. For actual instantiation it works as follows:
 
@@ -47,8 +47,9 @@ if (processes.Length > 0)
 
 `ResourceMode` defaults to `EmbeddedOnly`, so existing consumers do not start network requests merely by
 updating the package. `RemotePreferred` validates Hermes v2 remote bytes first, then falls back to the last
-verified cache and finally the package's embedded manifest. Initialization uses one manifest revision for
-both the CHATLOG signature/structure and standard Talk offsets.
+valid cache and finally the package's embedded manifest. Remote and cached manifests may use the
+`generated` status for CI-published resources or the legacy `live-verified` status. Initialization
+uses one manifest revision for both the CHATLOG signature/structure and standard Talk offsets.
 The default latest pointer is `https://hermes.sapphosound.com/v2/latest.json`, under the Hermes v2 public
 base `https://hermes.sapphosound.com/v2/`.
 

--- a/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
+++ b/Sharlayan.Tests/Resources/HermesV2ManifestTests.cs
@@ -34,6 +34,42 @@ namespace Sharlayan.Tests.Resources {
         }
 
         [Fact]
+        public void RemoteParserAcceptsGeneratedValidationWithoutLiveMetadata() {
+            byte[] bytes = CreateGeneratedManifest();
+
+            HermesV2Manifest manifest = HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.1", allowCandidate: false);
+
+            Assert.Equal("generated", manifest.Validation.Status);
+            Assert.Null(manifest.Validation.GameVersion);
+            Assert.Null(manifest.Validation.ExecutableSha256);
+            Assert.Null(manifest.Validation.VerifierCommit);
+        }
+
+        [Fact]
+        public void GeneratedManifestRequiresCompatibleClientAndRejectsLiveMetadata() {
+            byte[] bytes = CreateGeneratedManifest();
+            JObject withLiveMetadata = JObject.Parse(Encoding.UTF8.GetString(bytes));
+            withLiveMetadata["validation"]["gameVersion"] = "2026.07.16.0001.0000";
+            JObject withOlderFloor = JObject.Parse(Encoding.UTF8.GetString(bytes));
+            withOlderFloor["compatibility"]["minimumSharlayanVersion"] = "9.2.0";
+
+            Assert.Throws<InvalidDataException>(() =>
+                HermesV2ManifestParser.ParseManifest(bytes, null, "9.2.0", allowCandidate: false));
+            Assert.Throws<InvalidDataException>(() =>
+                HermesV2ManifestParser.ParseManifest(
+                    Encoding.UTF8.GetBytes(withOlderFloor.ToString(Newtonsoft.Json.Formatting.None)),
+                    null,
+                    "9.2.1",
+                    allowCandidate: false));
+            Assert.Throws<InvalidDataException>(() =>
+                HermesV2ManifestParser.ParseManifest(
+                    Encoding.UTF8.GetBytes(withLiveMetadata.ToString(Newtonsoft.Json.Formatting.None)),
+                    null,
+                    "9.2.1",
+                    allowCandidate: false));
+        }
+
+        [Fact]
         public void ParserRejectsRevisionMismatchAndNewerMinimumVersion() {
             byte[] bytes = CreateLiveManifest("99.0.0");
 
@@ -205,6 +241,15 @@ namespace Sharlayan.Tests.Resources {
                 ["gameVersion"] = "7.51",
                 ["executableSha256"] = new string('c', 64),
                 ["verifierCommit"] = new string('d', 40),
+            };
+            return new UTF8Encoding(false).GetBytes(json.ToString(Newtonsoft.Json.Formatting.Indented) + "\n");
+        }
+
+        internal static byte[] CreateGeneratedManifest() {
+            JObject json = JObject.Parse(Encoding.UTF8.GetString(ReadEmbeddedFixture()));
+            json["compatibility"]["minimumSharlayanVersion"] = "9.2.1";
+            json["validation"] = new JObject {
+                ["status"] = "generated",
             };
             return new UTF8Encoding(false).GetBytes(json.ToString(Newtonsoft.Json.Formatting.Indented) + "\n");
         }

--- a/Sharlayan.Tests/Resources/HermesV2ResourceProviderTests.cs
+++ b/Sharlayan.Tests/Resources/HermesV2ResourceProviderTests.cs
@@ -16,6 +16,43 @@ namespace Sharlayan.Tests.Resources {
 
     public sealed class HermesV2ResourceProviderTests {
         [Fact]
+        public async Task GeneratedRemoteManifestIsCachedAndUsedWhenNetworkFails() {
+            string cacheDirectory = Path.Combine(Path.GetTempPath(), "sharlayan-hermes-tests-" + Guid.NewGuid().ToString("N"));
+            try {
+                byte[] manifestBytes = HermesV2ManifestTests.CreateGeneratedManifest();
+                string revision = HermesV2ManifestParser.CalculateRevision(manifestBytes);
+                byte[] latestBytes = CreateLatest(revision);
+                FakeTransport transport = new FakeTransport(
+                    new HermesHttpResponse(HttpStatusCode.OK, latestBytes, "\"generated\""),
+                    new HermesHttpResponse(HttpStatusCode.OK, manifestBytes, null));
+                SharlayanConfiguration configuration = new SharlayanConfiguration {
+                    ResourceMode = ResourceMode.RemotePreferred,
+                    HermesV2LatestUri = new Uri("https://example.test/v2/latest.json"),
+                    ResourceCacheDirectory = cacheDirectory,
+                };
+
+                IReadOnlyList<HermesManifestCandidate> remote = await new HermesV2ResourceProvider(
+                    configuration,
+                    transport,
+                    "9.2.1").GetCandidatesAsync(CancellationToken.None);
+                IReadOnlyList<HermesManifestCandidate> fallback = await new HermesV2ResourceProvider(
+                    configuration,
+                    new ThrowingTransport(),
+                    "9.2.1").GetCandidatesAsync(CancellationToken.None);
+
+                Assert.Equal(ResourceSource.Remote, remote[0].Info.Source);
+                Assert.Equal("generated", remote[0].Info.ValidationStatus);
+                Assert.Equal(revision, remote[0].Info.ResourceRevision);
+                Assert.Equal(ResourceSource.Cache, fallback[0].Info.Source);
+                Assert.Equal("generated", fallback[0].Info.ValidationStatus);
+                Assert.Equal(revision, fallback[0].Info.ResourceRevision);
+            }
+            finally {
+                if (Directory.Exists(cacheDirectory)) Directory.Delete(cacheDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
         public async Task RemoteManifestIsCachedAndUsedWhenNetworkFails() {
             string cacheDirectory = Path.Combine(Path.GetTempPath(), "sharlayan-hermes-tests-" + Guid.NewGuid().ToString("N"));
             try {
@@ -87,7 +124,7 @@ namespace Sharlayan.Tests.Resources {
         }
 
         [Fact]
-        public async Task NotModifiedLatestUsesVerifiedCache() {
+        public async Task NotModifiedLatestUsesValidCache() {
             string cacheDirectory = Path.Combine(Path.GetTempPath(), "sharlayan-hermes-tests-" + Guid.NewGuid().ToString("N"));
             try {
                 byte[] manifestBytes = HermesV2ManifestTests.CreateLiveManifest();

--- a/Sharlayan/Resources/HermesV2ManifestParser.cs
+++ b/Sharlayan/Resources/HermesV2ManifestParser.cs
@@ -280,7 +280,7 @@ namespace Sharlayan.Resources {
 
             JObject validation = RequireObject(root, "validation", "$.");
             string status = RequireString(validation, "status", "$.validation.");
-            if (status == "candidate") {
+            if (status == "candidate" || status == "generated") {
                 ValidateObject(validation, "$.validation", "status");
             }
             else {
@@ -481,7 +481,7 @@ namespace Sharlayan.Resources {
 
             HermesBattleTalkResource battleTalk = manifest.Resources.BattleTalk;
             if (battleTalk != null) {
-                if (manifest.Compatibility.MinimumSharlayanVersion != "9.2.0"
+                if (CompareSemanticVersions(manifest.Compatibility.MinimumSharlayanVersion, "9.2.0") < 0
                     || battleTalk.Root != "framework"
                     || battleTalk.Semantics != "currentBattleTalk"
                     || battleTalk.AddonName != "_BattleTalk"
@@ -543,8 +543,18 @@ namespace Sharlayan.Resources {
                     throw new InvalidDataException("Live verification metadata is incomplete.");
                 }
             }
+            else if (validation.Status == "generated") {
+                if (CompareSemanticVersions(manifest.Compatibility.MinimumSharlayanVersion, "9.2.1") < 0) {
+                    throw new InvalidDataException("Generated manifests require Sharlayan.Lite 9.2.1 or newer.");
+                }
+                if (!string.IsNullOrEmpty(validation.GameVersion)
+                    || !string.IsNullOrEmpty(validation.ExecutableSha256)
+                    || !string.IsNullOrEmpty(validation.VerifierCommit)) {
+                    throw new InvalidDataException("Generated manifests must not contain live verification metadata.");
+                }
+            }
             else if (!(allowCandidate && validation.Status == "candidate")) {
-                throw new InvalidDataException("Only live-verified remote and cache manifests are accepted.");
+                throw new InvalidDataException("Only generated or live-verified remote and cache manifests are accepted.");
             }
         }
 

--- a/Sharlayan/Resources/HermesV2ResourceProvider.cs
+++ b/Sharlayan/Resources/HermesV2ResourceProvider.cs
@@ -96,7 +96,7 @@ namespace Sharlayan.Resources {
                     HermesV2Manifest cached = HermesV2ManifestParser.ParseManifest(cachedManifest, latest.ResourceRevision, this._clientVersion, allowCandidate: false);
                     EnsureLatestMatchesManifest(latest, cached);
                     this._cache.WriteLatest(latestBytes, latestEtag);
-                    return CreateCandidate(cached, cachedManifest, ResourceSource.Cache, latest.ResourceRevision, "Remote latest selected an existing verified cache entry.");
+                    return CreateCandidate(cached, cachedManifest, ResourceSource.Cache, latest.ResourceRevision, "Remote latest selected an existing valid cache entry.");
                 }
                 catch {
                     this._cache.QuarantineManifest(latest.ResourceRevision);

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -15,12 +15,12 @@
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<PackageValidationBaselineVersion>8.0.1</PackageValidationBaselineVersion>
-		<Version>9.2.0</Version>
+		<Version>9.2.1</Version>
 		<Company>SyndicatedLife</Company>
 		<Product>Sharlayan.Lite</Product>
 		<Description>Lightweight FFXIV memory scanning with ChatLog and dialogue UI reading.</Description>
 		<Copyright>Copyright © 2007 - 2024 Ryan Wilson</Copyright>
-		<FileVersion>9.2.0.0</FileVersion>
+		<FileVersion>9.2.1.0</FileVersion>
 		<AssemblyVersion>8.0.0.0</AssemblyVersion>
 		<RootNamespace>Sharlayan</RootNamespace>
 		<PackageId>Sharlayan.Lite</PackageId>

--- a/tools/Sharlayan.PackageContractConsumer/Sharlayan.PackageContractConsumer.csproj
+++ b/tools/Sharlayan.PackageContractConsumer/Sharlayan.PackageContractConsumer.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <SharlayanPackageVersion Condition="'$(SharlayanPackageVersion)' == ''">9.2.0</SharlayanPackageVersion>
+    <SharlayanPackageVersion Condition="'$(SharlayanPackageVersion)' == ''">9.2.1</SharlayanPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- accept Hermes v2 generated manifests from remote or cache
- require generated manifests to target Sharlayan.Lite 9.2.1 or newer and omit live-verification metadata
- add remote/cache fallback coverage and update package metadata to 9.2.1

## Impact
This enables transparent CI-published Hermes resources while older clients continue to reject the new status and fall back safely.

## Validation
- dotnet test Sharlayan.Tests/Sharlayan.Tests.csproj --configuration Release --nologo (78/78 on net8.0 and net10.0)
- Release package verification against commit cb4aa26696959de8e6f110b06325e6382c9b7a63
- clean package consumer build with Talk and BattleTalk APIs